### PR TITLE
Add: Implement some changes for GameModeList and GameModeDescription

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,8 +8,7 @@ import AboutUsSection from "./components/AboutUsSection";
 import SignIn from "./pages/auth/SignIn";
 import AccountSettings from "./components/AccountSettings";
 import WhyShouldYouPlaySection from "./components/why-should-you-play-section";
-import GameModeDescription from "./components/GameMode/GameModeDescription";
-import GameModesList from "./components/GameMode/GameModesList";
+import GameModeSection from "./components/GameMode/GameModeSection";
 import Footer from "./components/Footer";
 import { RecentActivity } from "./components/RecentActivity";
 import { mockActivities } from "./models/recentActivity";
@@ -26,8 +25,7 @@ const Home = () => (
     <AboutUsSection />
     <ContributorsSection />
     <FaqsSection />
-    <GameModeDescription />
-    <GameModesList />
+    <GameModeSection />
     <RecentActivity activities={mockActivities} />
     <Footer />
   </>

--- a/src/components/GameMode/GameModeDescription.tsx
+++ b/src/components/GameMode/GameModeDescription.tsx
@@ -1,43 +1,60 @@
 import React from 'react'
-import { useAppSelector } from '../../hooks'
-import type { GameModeDetail } from './gameSliceStore'
+import type { GameModeDetail } from '../../data/gameModes'
+import bagCoins from '/bag-coins.svg'
 
-const SubHeaderText = ({ children }: { children: string }) => <h3 className='text-lg lg:text-xl text-white font-medium'>
+const SubHeaderText = ({ children }: { children: string }) => <h3 className='text-[10px] md:text-[11px] text-[#57E8D3] font-medium uppercase tracking-[0.14em]'>
    {children}
 </h3>
 
 const Container: React.FC<{ children: React.ReactNode }> = ({ children }: { children: React.ReactNode }) => (
-    <div className='border border-[#323336] rounded-sm p-4 xl:p-5 w-full text-left flex flex-col gap-5 leading-[100%] cursor-pointer'>
+    <div className='border border-[#1A2429] rounded-sm p-3 md:p-3.5 w-full text-left flex flex-col gap-2.5 leading-[100%] bg-[#0A1117] shadow-[inset_0_0_14px_rgba(4,17,22,0.65)]'>
         {children}
     </div>
 )
 
 const Paragraph = ({ children }: { children: string }) => (
-    <p className='text-white text-md md:text-base lg:text-lg font-light text-left'>
+    <p className='text-[#D8E3E5] text-[11px] md:text-xs font-light text-left leading-relaxed uppercase'>
         {children}
     </p>
 )
 
-const GameModeDescription = () => {
-  const gameState = useAppSelector((state) => state.game)
-  const { allModes, selectedModeId } = gameState
-  const selectedMode = allModes.find((mode: GameModeDetail) => mode.id === selectedModeId)
-  const currentMode = selectedMode || allModes[0]
+const StatItem = ({ label, value }: { label: string; value: string | number }) => (
+  <div className='flex flex-col gap-1 items-center min-w-[3.7rem]'>
+    <span className='text-[#5FD9CB] text-[9px] uppercase tracking-[0.12em]'>{label}</span>
+    <span className='text-white text-[11px] md:text-xs font-medium'>{value}</span>
+  </div>
+)
 
-  // Guard against missing data to avoid runtime errors
+interface GameModeDescriptionProps {
+  currentMode: GameModeDetail | null
+}
+
+const GameModeDescription = ({ currentMode }: GameModeDescriptionProps) => {
   if (!currentMode) {
     return null
   }
 
   return (
-    <div className='flex flex-col gap-4 lg:gap-8'>
-      <div className='relative text-xl font-light uppercase'>
-        <div className='w-full block shadow-[inset_3px_3px_24px_#033330] bg-[#02211F] h-14 lg:h-16 xl:h-18.25 mix-blend-color rounded-[11px] [clip-path:polygon(0%_0%,100%_0%,100%_73%,0%_100%)] -skew-x-20 text-white -top-10 xl:-top-20 '></div>
-        <h4 className='absolute top-1/2 left-2/7 lg:left-1/7 transform -translate-x-1/2 -translate-y-1/2 text-white text-md md:text-base lg:text-lg font-light text-left tracking-wide '>
-          {currentMode.name}
-        </h4>
-      </div>
-      <article className='w-[97%] lg:w-151.5 text-white font-light uppercase flex flex-col gap-4'>
+    <div className='w-full xl:flex-1 flex flex-col gap-3 transition-all duration-300 ease-out'>
+      <article
+        key={currentMode.id}
+        className='w-full text-white font-light uppercase flex flex-col gap-2.5 opacity-100 translate-y-0 transition-all duration-300 ease-out'
+      >
+        <section className='border border-[#162029] rounded-sm p-3 bg-[#090F15]'>
+          <div className='flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-4'>
+            <img src={bagCoins} alt='' className='h-12 w-12 md:h-14 md:w-14 object-contain select-none pointer-events-none' />
+            <div className='grid grid-cols-3 gap-2 sm:gap-3 w-full sm:w-auto'>
+              <StatItem label='Questions' value={currentMode.questionCount === 0 ? '∞' : currentMode.questionCount} />
+              <StatItem label='Duration' value={currentMode.duration} />
+              <StatItem label='Max Score' value={currentMode.maxScore === 0 ? '∞' : currentMode.maxScore.toLocaleString()} />
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <SubHeaderText>{currentMode.name}</SubHeaderText>
+        </section>
+
         <section>
           <Container>
             <SubHeaderText>Description</SubHeaderText>
@@ -48,7 +65,7 @@ const GameModeDescription = () => {
         <section>
           <Container>
             <SubHeaderText>Features</SubHeaderText>
-            <ul className='list-disc list-inside text-white text-sm lg:text-base font-light'>
+            <ul className='list-disc list-inside text-[#D8E3E5] text-[11px] md:text-xs font-light space-y-1 leading-relaxed'>
               {currentMode.features.map((feature: string, idx: number) => (
                 <li key={idx}>{feature}</li>
               ))}
@@ -58,8 +75,8 @@ const GameModeDescription = () => {
 
         <section>
           <Container>
-            <SubHeaderText>Instructions</SubHeaderText>
-            <ul className='list-disc list-inside text-white text-sm lg:text-base font-light'>
+            <SubHeaderText>Instruction</SubHeaderText>
+            <ul className='list-disc list-inside text-[#D8E3E5] text-[11px] md:text-xs font-light space-y-1 leading-relaxed'>
               {currentMode.instructions.map((instruction: string, idx: number) => (
                 <li key={idx}>{instruction}</li>
               ))}

--- a/src/components/GameMode/GameModeSection.tsx
+++ b/src/components/GameMode/GameModeSection.tsx
@@ -1,0 +1,30 @@
+import { useMemo, useState } from 'react'
+import GameModeDescription from './GameModeDescription'
+import GameModesList from './GameModesList'
+import { gameModes } from '../../data/gameModes'
+
+const GameModeSection = () => {
+  const [selectedModeId, setSelectedModeId] = useState<string>(gameModes[0]?.id ?? '')
+
+  const currentMode = useMemo(
+    () => gameModes.find((mode) => mode.id === selectedModeId) ?? gameModes[0] ?? null,
+    [selectedModeId],
+  )
+
+  return (
+    <section className='w-full px-4 md:px-8 lg:px-10 py-8 lg:py-12'>
+      <div className='mx-auto max-w-[70rem] border border-[#111A21] rounded-sm bg-[#070D13] p-3 md:p-4 lg:p-5 shadow-[0_0_30px_rgba(0,0,0,0.28)]'>
+        <div className='flex flex-col xl:flex-row gap-4 xl:gap-5 items-start'>
+        <GameModeDescription currentMode={currentMode} />
+        <GameModesList
+          allModes={gameModes}
+          selectedModeId={selectedModeId}
+          onModeSelect={setSelectedModeId}
+        />
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export default GameModeSection

--- a/src/components/GameMode/GameModesList.tsx
+++ b/src/components/GameMode/GameModesList.tsx
@@ -1,41 +1,41 @@
-import gameModeCategory from '../../assets/game-mode-categories.png'
-import { useAppDispatch, useAppSelector } from '../../hooks'
-import { setGameMode } from './gameSliceStore'
-import type { GameModeDetail } from './gameSliceStore'
-import GameModeDropdown from '../gameModes/GameModeDropdown'
+import type { GameModeDetail } from '../../data/gameModes'
 
-const GameModesList = () => {
-  const dispatch = useAppDispatch()
-  const { allModes, selectedModeId } = useAppSelector((state) => state.game)
+interface GameModesListProps {
+  allModes: GameModeDetail[]
+  selectedModeId: string
+  onModeSelect: (modeId: string) => void
+}
 
+const GameModesList = ({ allModes, selectedModeId, onModeSelect }: GameModesListProps) => {
   return (
-    <aside className='w-82 xl:w-100 2xl:w-122.5 flex flex-col gap-9 justify-center items-center m-3'>
-      <figure>
-        <img
-          src={gameModeCategory}
-          alt="Game Mode Categories"
-          className='h-auto select-none pointer-events-none'
-        />
-      </figure>
-
-      <div className="w-full flex justify-center">
-        <GameModeDropdown />
+    <aside className='w-full xl:max-w-[16rem] flex flex-col gap-3'>
+      <div className='relative flex items-center justify-center h-9'>
+        <span className='text-[10px] md:text-[11px] uppercase tracking-[0.18em] text-[#57E8D3] border border-[#2A4A4A] px-4 py-1 rounded-sm bg-[#061315]'>
+          Categories
+        </span>
       </div>
 
-      <ol className='flex flex-col gap-3 lg:gap-5 justify-center items-center w-full text-white uppercase text-xl md:text-2xl xl:text-3xl font-medium'>
-        {allModes.map((mode: GameModeDetail) => (
-          <li
-            key={mode.id}
-            onClick={() => dispatch(setGameMode(mode.id))}
-            className={`border border-[#323336] rounded-sm p-3 md:p-4 xl:p-4 w-full text-center leading-[100%] cursor-pointer transition-colors ${
-              selectedModeId === mode.id
-                ? 'bg-[#01100F] text-[#43AD6C]'
-                : 'hover:bg-[#01100F] hover:text-[#43AD6C]'
-            }`}
-          >
-            {mode.name}
-          </li>
-        ))}
+      <ol className='flex flex-col gap-1.5 w-full text-white uppercase text-[11px] md:text-xs font-normal tracking-wide'>
+        {allModes.map((mode: GameModeDetail) => {
+          const isActive = selectedModeId === mode.id
+
+          return (
+            <li key={mode.id} className='w-full'>
+              <button
+                type='button'
+                aria-pressed={isActive}
+                onClick={() => onModeSelect(mode.id)}
+                className={`w-full border rounded-sm px-3 py-2 text-left leading-tight cursor-pointer transition-all duration-300 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#43AD6C]/70 ${
+                  isActive
+                    ? 'border-[#1D3B3E] bg-[#0F2D2B] text-white shadow-[inset_0_0_20px_rgba(20,101,92,0.35)]'
+                    : 'border-[#1D2529] bg-[#0B1014] text-[#D9E2E1] hover:border-[#2D5052] hover:bg-[#0D2022] hover:text-white'
+                }`}
+              >
+                {mode.name}
+              </button>
+            </li>
+          )
+        })}
       </ol>
     </aside>
   )

--- a/src/data/gameModes.ts
+++ b/src/data/gameModes.ts
@@ -1,0 +1,173 @@
+export interface GameModeDetail {
+  id: string
+  name: string
+  description: string
+  questionCount: number
+  duration: string
+  maxScore: number
+  features: string[]
+  instructions: string[]
+}
+
+export const gameModes: GameModeDetail[] = [
+  {
+    id: 'classic',
+    name: 'Classic Mode',
+    description:
+      'Answer a series of timed questions. Each question has four options, and you must choose the correct one before time runs out.',
+    questionCount: 10,
+    duration: '15 min',
+    maxScore: 5000,
+    features: [
+      'Standard scoring based on accuracy and speed.',
+      'Leaderboard ranking for competitive play.',
+    ],
+    instructions: [
+      'Start the game and read the question carefully.',
+      'Select one of the four options (A, B, C, or D).',
+      'You have 2 minutes per question to submit your answer.',
+      'Your final score combines accuracy and response speed.',
+      'Complete as many correct answers as possible before time expires.',
+    ],
+  },
+  {
+    id: 'challenge',
+    name: 'Challenge Mode',
+    description:
+      'Play a fixed number of high-pressure questions with limited time for each attempt.',
+    questionCount: 12,
+    duration: '12 min',
+    maxScore: 6000,
+    features: [
+      'Bonus points for faster correct answers.',
+      'Optional lifelines such as removing two wrong options.',
+    ],
+    instructions: [
+      'Choose the challenge length before starting.',
+      'Answer each question within the given time limit.',
+      'Use lifelines strategically when needed.',
+      'Aim for perfect accuracy while keeping pace.',
+      'Finish with the highest possible score.',
+    ],
+  },
+  {
+    id: 'daily',
+    name: 'Daily Challenge',
+    description:
+      'Take on a fresh daily set of questions and compare your performance with other players.',
+    questionCount: 10,
+    duration: '10 min',
+    maxScore: 5500,
+    features: [
+      'New challenge set every day.',
+      'Daily leaderboard tracking and rewards.',
+    ],
+    instructions: [
+      'Open the daily mode to access the current challenge set.',
+      'Answer all questions in one run.',
+      'Your run is scored immediately after completion.',
+      'Return tomorrow for a new question set.',
+      'Improve your daily rank over time.',
+    ],
+  },
+  {
+    id: 'timed-blitz',
+    name: 'Timed Blitz',
+    description:
+      'Rapid-fire mode where you answer as many questions as possible within a strict global timer.',
+    questionCount: 20,
+    duration: '8 min',
+    maxScore: 6500,
+    features: [
+      'Fast pace with short response windows.',
+      'Combo-style scoring for consecutive correct answers.',
+    ],
+    instructions: [
+      'Start the blitz and monitor the global countdown.',
+      'Answer quickly to maximize total attempts.',
+      'Keep a streak to earn score multipliers.',
+      'Avoid slow responses that waste valuable time.',
+      'Submit your run when the timer ends.',
+    ],
+  },
+  {
+    id: 'puzzle',
+    name: 'Puzzle Mode',
+    description:
+      'Solve logic-focused puzzles that emphasize reasoning over speed.',
+    questionCount: 8,
+    duration: '18 min',
+    maxScore: 5200,
+    features: [
+      'Higher-difficulty logic and pattern questions.',
+      'Hints available for selected puzzle types.',
+    ],
+    instructions: [
+      'Read each puzzle carefully before answering.',
+      'Use hints only when necessary to avoid penalties.',
+      'Take time to reason through each option.',
+      'Submit the best answer based on your deduction.',
+      'Complete the set for your puzzle score.',
+    ],
+  },
+  {
+    id: 'practice',
+    name: 'Practice Mode',
+    description:
+      'Low-pressure mode designed for learning and experimentation without rank penalties.',
+    questionCount: 15,
+    duration: 'No limit',
+    maxScore: 0,
+    features: [
+      'No leaderboard impact.',
+      'Great for reviewing concepts and strategies.',
+    ],
+    instructions: [
+      'Pick a category or difficulty level.',
+      'Answer at your own pace without time pressure.',
+      'Review feedback after each question.',
+      'Repeat questions to improve retention.',
+      'Use this mode to prepare for ranked play.',
+    ],
+  },
+  {
+    id: 'adventure',
+    name: 'Adventure Mode',
+    description:
+      'Progress through themed stages with increasing difficulty and milestone rewards.',
+    questionCount: 14,
+    duration: '20 min',
+    maxScore: 7000,
+    features: [
+      'Stage-based progression system.',
+      'Unlockables and milestone bonuses.',
+    ],
+    instructions: [
+      'Begin at stage one and complete all questions.',
+      'Meet score targets to unlock the next stage.',
+      'Use earned rewards to support later stages.',
+      'Track your progress on the adventure path.',
+      'Complete all stages for full completion.',
+    ],
+  },
+  {
+    id: 'endless',
+    name: 'Endless Mode',
+    description:
+      'Play continuously until you miss, with difficulty scaling over time.',
+    questionCount: 0,
+    duration: 'Endless',
+    maxScore: 0,
+    features: [
+      'Infinite question stream.',
+      'Difficulty ramps up as your streak grows.',
+    ],
+    instructions: [
+      'Start the run and answer each question correctly.',
+      'Continue building your streak for a higher score.',
+      'Expect harder questions as the run progresses.',
+      'One wrong answer ends the session.',
+      'Set a new personal best and try again.',
+    ],
+  },
+]


### PR DESCRIPTION
closes #43 

What I changed
Reworked Game Mode into one controlled section with local state:

- GameModeSection.tsx
- First mode is selected by default.

Updated list UI to match the right-side “Categories” panel style from the design:

- GameModeList.tsx
- Compact stacked buttons, active/hover states, keyboard-accessible buttons.

Updated description UI to match the left-side card structure:

- GameModeDescription.tsx
- Top stats row (icon + meta), then MODE, DESCRIPTION, FEATURES, INSTRUCTION panels.
- smooth transition on mode switch.

Moved mode data to a shared dynamic source:

- gameModes.ts
- Added questionCount, duration, maxScore fields for the top stat row.

Rewired app to render the unified section:

- App.tsx