### PR TITLE
feature:Regression: Navbar routes to non-existent pages in active rou…

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,8 @@ import { GetStarted } from "./pages/GetStarted";
 import ToastViewport from "./components/toasts/ToastViewport";
 import Navbar from "./components/Navbar";
 import GameplayNavbar from "./components/GameplayNavbar";
+import Store from "./pages/Store";
+import GameMode from "./pages/GameMode";
 
 const Home = () => (
   <>
@@ -47,6 +49,16 @@ function App() {
         <Route path="/settings" element={<AccountSettings />} />
         <Route path="/leaderboard" element={<LeaderboardPage />} />
         <Route path="/get-started" element={<GetStarted />} />
+        <Route path="/store" element={<Store />} />
+        <Route path="/game-mode" element={<GameMode />} />
+        <Route
+          path="*"
+          element={
+            <div className="h-screen flex items-center justify-center text-white text-2xl">
+              404 — Page Not Found
+            </div>
+          }
+        />
       </Routes>
     </>
   );


### PR DESCRIPTION
closes #70




Summary
After recent navbar and routing updates, the desktop/mobile navbar links for Store and Game mode navigate to paths that are not registered in the router currently mounted by the app. This creates dead-end navigation and a near-empty view state for users.

Severity
Moderate-High

Type
Bug, Regression, Routing

Current Behavior
Clicking Store or Game mode in the navbar navigates to /store or /game-mode.
Those routes are not defined in the active route tree.
The active router in App has no wildcard fallback route, so unmatched paths render no page content (only shared chrome), which feels like a broken app state.
Expected Behavior
Navbar links should only target valid routes.
Store and Game mode should either:
Be registered in the active router and render pages, or
Be changed back to in-page section links on Home if that was the intended UX.
Unmatched routes should render a clear 404/fallback page.
Steps to Reproduce
Start the app.
Open any page where the standard navbar is visible.
Click Store.
Observe navigation to /store with no corresponding route view.
Repeat with Game mode (/game-mode).
Navigate directly to an unknown route (e.g. /random-test-path) and observe the missing fallback page in the active router.
Impact
Primary navigation leads users into non-functional states.
Conversion/engagement risk: users can't reliably reach expected content from top-level nav.
Perceived quality/reliability drop on core user journey.
Likely regression from previous merged navbar/routing changes.
Evidence
Navbar links point to /store and /game-mode → Navbar.tsx
Active router does not define /store or /game-mode → App.tsx
Active router also lacks wildcard fallback → App.tsx
Separate route map exists with different routes but is not mounted → AppRoutes.tsx
Placeholder pages exist but are not wired in active router → Store.tsx, GameMode.tsx
Regression Context
Potentially related to prior navbar/routing work:

[https://github.com/MindFlowInteractive/quest-frontend/pull/50](https://www.drips.network/external/https%3A%2F%2Fgithub.com%2FMindFlowInteractive%2Fquest-frontend%2Fpull%2F50)
[https://github.com/MindFlowInteractive/quest-frontend/pull/61](https://www.drips.network/external/https%3A%2F%2Fgithub.com%2FMindFlowInteractive%2Fquest-frontend%2Fpull%2F61)
[https://github.com/MindFlowInteractive/quest-frontend/pull/63](https://www.drips.network/external/https%3A%2F%2Fgithub.com%2FMindFlowInteractive%2Fquest-frontend%2Fpull%2F63)
Proposed Fix
Consolidate to a single source of truth for routes (either App or AppRoutes, not both).
Register /store and /game-mode in the active router if those pages are intended.
Add a wildcard route fallback in the active router.
Ensure navbar links are generated from the same route config to prevent future drift.
Add a small routing regression test checklist for all top-nav items.
Acceptance Criteria
 Clicking every navbar item lands on a valid rendered page or intended in-page section.
 /store and /game-mode are either fully functional routes or removed from nav.
 Unknown routes show a visible 404/fallback page.
 No duplicate/competing route definitions remain without clear ownership.