### PR TITLE
fix(a11y): keyboard navigation, focus visibility, and modal traps (#87)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,6 +71,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.6.tgz",
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -1756,6 +1757,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.9.tgz",
       "integrity": "sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==",
       "devOptional": true,
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1772,6 +1774,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.8.tgz",
       "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
       "devOptional": true,
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1889,6 +1892,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.53.0.tgz",
       "integrity": "sha512-npiaib8XzbjtzS2N4HlqPvlpxpmZ14FjSJrteZpPxGUaYPlvhzlzUZ4mZyABo0EFrOWnvyd0Xxroq//hKhtAWg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.0",
         "@typescript-eslint/types": "8.53.0",
@@ -2127,6 +2131,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2261,6 +2266,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2510,6 +2516,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3488,6 +3495,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3514,6 +3522,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3577,6 +3586,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3585,6 +3595,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3603,6 +3614,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -3686,7 +3698,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -3848,7 +3861,8 @@
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
       "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -3907,6 +3921,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3996,6 +4011,7 @@
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4112,6 +4128,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "dev": true,
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/components/GameplayNavbar.tsx
+++ b/src/components/GameplayNavbar.tsx
@@ -1,10 +1,142 @@
-import { useState } from "react";
+import { useEffect, useId, useState } from "react";
 import { Menu, X } from "lucide-react";
-import { Link } from "react-router-dom";
+import { Link, NavLink, useNavigate } from "react-router-dom";
 import { Link as ScrollLink } from "react-scroll";
+import { clearSession } from "../session/clearSession";
+
+type MenuEntry =
+  | { kind: "scroll"; name: string; hash: string }
+  | { kind: "route"; name: string; to: string }
+  | { kind: "lifeline"; name: string; image: string }
+  | { kind: "notifications"; image: string }
+  | { kind: "logout"; image: string }
+  | { kind: "profile"; image: string };
+
+const menuEntries: MenuEntry[] = [
+  { kind: "scroll", name: "How to Play", hash: "how-to-play" },
+  { kind: "scroll", name: "About", hash: "about" },
+  { kind: "scroll", name: "Contributors", hash: "contributors" },
+  { kind: "scroll", name: "FAQs", hash: "faqs" },
+  { kind: "route", name: "Setting", to: "/settings" },
+  { kind: "lifeline", name: "Coins", image: "/coins.svg" },
+  { kind: "lifeline", name: "Call a friend", image: "/call.svg" },
+  { kind: "lifeline", name: "50:50", image: "/fiftyfifty.svg" },
+  { kind: "lifeline", name: "Audience", image: "/audience.svg" },
+  { kind: "notifications", image: "/bell.svg" },
+  { kind: "logout", image: "/logout.svg" },
+  { kind: "profile", image: "/manfists.png" },
+];
+
+const linkFocus =
+  "cursor-pointer hover:text-white hover:transition-colors text-[#F9BC07] rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F9BC07] focus-visible:ring-offset-2 focus-visible:ring-offset-[#01100F]";
+
+const mobileFocus =
+  "cursor-pointer hover:text-white hover:transition-colors text-[#F9BC07] rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F9BC07] focus-visible:ring-offset-2 focus-visible:ring-offset-[#323336]";
+
+const iconBtn =
+  "p-0 border-0 bg-transparent cursor-pointer rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F9BC07] focus-visible:ring-offset-2 focus-visible:ring-offset-[#01100F]";
+
+const iconBtnMobile =
+  "p-0 border-0 bg-transparent cursor-pointer rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F9BC07] focus-visible:ring-offset-2 focus-visible:ring-offset-[#323336]";
 
 const NavBar = () => {
   const [isOpen, setIsOpen] = useState(false);
+  const navigate = useNavigate();
+  const mobileMenuId = useId();
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setIsOpen(false);
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [isOpen]);
+
+  const handleLogout = () => {
+    clearSession();
+    navigate("/sign-in", { replace: true });
+  };
+
+  const renderEntry = (item: MenuEntry, mobile: boolean) => {
+    const f = mobile ? mobileFocus : linkFocus;
+    if (item.kind === "scroll") {
+      return (
+        <ScrollLink
+          to={item.hash}
+          spy={true}
+          smooth={true}
+          offset={-70}
+          duration={500}
+          activeClass="text-white"
+          className={f}
+          onClick={mobile ? () => setIsOpen(false) : undefined}
+        >
+          {item.name}
+        </ScrollLink>
+      );
+    }
+    if (item.kind === "route") {
+      return (
+        <NavLink
+          to={item.to}
+          className={({ isActive }) =>
+            `${f} ${isActive ? "text-white font-bold" : ""}`
+          }
+          onClick={mobile ? () => setIsOpen(false) : undefined}
+        >
+          {item.name}
+        </NavLink>
+      );
+    }
+    if (item.kind === "lifeline") {
+      return (
+        <span
+          className={`flex items-center gap-2 ${mobile ? "text-[#F9BC07]" : "text-[#F9BC07]"}`}
+          aria-hidden="true"
+        >
+          <span>{item.name}</span>
+          <img src={item.image} alt="" className={mobile ? "ml-1 object-contain" : "ml-2 object-contain"} />
+        </span>
+      );
+    }
+    if (item.kind === "notifications") {
+      return (
+        <button
+          type="button"
+          className={mobile ? iconBtnMobile : iconBtn}
+          aria-label="Notifications"
+        >
+          <img src={item.image} alt="" className={mobile ? "ml-1 object-contain" : "ml-2 object-contain"} />
+        </button>
+      );
+    }
+    if (item.kind === "logout") {
+      return (
+        <button
+          type="button"
+          onClick={() => {
+            if (mobile) setIsOpen(false);
+            handleLogout();
+          }}
+          className={mobile ? iconBtnMobile : iconBtn}
+          aria-label="Log out"
+        >
+          <img src={item.image} alt="" className={mobile ? "ml-1 object-contain" : "ml-2 object-contain"} />
+        </button>
+      );
+    }
+    return (
+      <NavLink
+        to="/settings"
+        aria-label="Account settings"
+        className={mobile ? `${mobileFocus} inline-flex` : `${linkFocus} inline-flex`}
+        onClick={mobile ? () => setIsOpen(false) : undefined}
+      >
+        <img src={item.image} alt="" className={mobile ? "ml-1 object-contain" : "ml-2 object-contain"} />
+      </NavLink>
+    );
+  };
 
   return (
     <nav className="relative ">
@@ -12,164 +144,57 @@ const NavBar = () => {
         <div className="flex justify-between items-center">
           <Link
             to="/"
-            className="shrink-0 flex items-center gap-2.5 cursor-pointer"
+            className="shrink-0 flex items-center gap-2.5 cursor-pointer rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F9BC07] focus-visible:ring-offset-2 focus-visible:ring-offset-[#01100F]"
           >
-            <img src="/logo.svg" alt="LogiQuest" className="object-contain" />
+            <img src="/logo.svg" alt="" className="object-contain" />
             <h1 className="font-prompt font-bold text-[#CFFDED] text-[31px]">
-              LogiQuest
+              <span className="sr-only">LogiQuest home</span>
+              <span aria-hidden="true">LogiQuest</span>
             </h1>
           </Link>
 
           <div className="hidden xl:flex items-center ">
             <div className="flex justify-center text-base items-center gap-4">
-              {dataMenu.map((item, index) => {
-                if (item.link?.startsWith("#") && item.link.length > 1) {
-                  return (
-                    <ScrollLink
-                      key={index}
-                      to={item.link.substring(1)}
-                      spy={true}
-                      smooth={true}
-                      offset={-70}
-                      duration={500}
-                      activeClass="text-white"
-                      className="cursor-pointer hover:text-white hover:transition-colors text-[#F9BC07]"
-                    >
-                      {item.name}
-                    </ScrollLink>
-                  );
-                }
-
-                return (
-                  <Link
-                    key={index}
-                    to={item.link || "#"}
-                    className="cursor-pointer hover:text-white hover:transition-colors text-[#F9BC07]"
-                  >
-                    {item.image ? (
-                      <div className="flex items-center gap-2 cursor-pointer ">
-                        {item.name}
-                        <img
-                          src={item.image}
-                          alt={item.name}
-                          className="ml-2 object-contain"
-                        />
-                      </div>
-                    ) : (
-                      item.name
-                    )}
-                  </Link>
-                );
-              })}
+              {menuEntries.map((item, index) => (
+                <span key={index} className="inline-flex items-center">
+                  {renderEntry(item, false)}
+                </span>
+              ))}
             </div>
           </div>
 
           <div className="xl:hidden flex items-center">
             <button
+              type="button"
               onClick={() => setIsOpen(!isOpen)}
-              className="text-[#F9BC07]"
+              className="text-[#F9BC07] rounded-sm p-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F9BC07] focus-visible:ring-offset-2 focus-visible:ring-offset-[#01100F]"
+              aria-expanded={isOpen}
+              aria-controls={mobileMenuId}
+              aria-label={isOpen ? "Close menu" : "Open menu"}
             >
-              {isOpen ? <X size={32} /> : <Menu size={32} />}
+              {isOpen ? <X size={32} aria-hidden /> : <Menu size={32} aria-hidden />}
             </button>
           </div>
         </div>
       </div>
 
-      {isOpen && (
-        <div className="xl:hidden bg-[#323336] w-full px-10 pb-10 flex flex-col gap-6 absolute top-full left-0 z-50 border-t border-gray-800 shadow-2xl">
+      {isOpen ? (
+        <div
+          id={mobileMenuId}
+          className="xl:hidden bg-[#323336] w-full px-10 pb-10 flex flex-col gap-6 absolute top-full left-0 z-50 border-t border-gray-800 shadow-2xl"
+          role="presentation"
+        >
           <div className="flex flex-col text-base gap-6 pt-5">
-            {dataMenu.map((item, index) => {
-              if (item.link?.startsWith("#") && item.link.length > 1) {
-                return (
-                  <ScrollLink
-                    onClick={() => setIsOpen(false)}
-                    key={index}
-                    to={item.link.substring(1)}
-                    spy={true}
-                    smooth={true}
-                    offset={-70}
-                    duration={500}
-                    activeClass="text-white"
-                    className="cursor-pointer hover:text-white hover:transition-colors text-[#F9BC07]"
-                  >
-                    {item.name}
-                  </ScrollLink>
-                );
-              }
-
-              return (
-                <Link
-                  onClick={() => setIsOpen(false)}
-                  key={index}
-                  to={item.link || "#"}
-                  className="cursor-pointer hover:text-white hover:transition-colors text-[#F9BC07]"
-                >
-                  {item.image ? (
-                    <div className="flex items-center gap-2 cursor-pointer ">
-                      {item.name}
-                      <img
-                        src={item.image}
-                        alt={item.name}
-                        className="ml-1 object-contain"
-                      />
-                    </div>
-                  ) : (
-                    item.name
-                  )}
-                </Link>
-              );
-            })}
+            {menuEntries.map((item, index) => (
+              <span key={index} className="inline-flex">
+                {renderEntry(item, true)}
+              </span>
+            ))}
           </div>
         </div>
-      )}
+      ) : null}
     </nav>
   );
 };
 
 export default NavBar;
-
-const dataMenu = [
-  {
-    name: "How to Play",
-    link: "#how-to-play",
-  },
-  {
-    name: "About",
-    link: "#about",
-  },
-  {
-    name: "Contributors",
-    link: "#contributors",
-  },
-  {
-    name: "FAQs",
-    link: "#faqs",
-  },
-  {
-    name: "Setting",
-    link: "/settings",
-  },
-  {
-    name: "Coins",
-    link: "#",
-    image: "/coins.svg",
-  },
-  {
-    name: "Call a friend",
-    link: "#",
-    image: "/call.svg",
-  },
-  {
-    name: "50:50",
-    link: "#",
-    image: "/fiftyfifty.svg",
-  },
-  {
-    name: "Audience",
-    link: "#",
-    image: "/audience.svg",
-  },
-  { image: "/bell.svg", link: "#" },
-  { image: "/logout.svg", link: "#" },
-  { image: "/manfists.png", link: "#" },
-];

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,45 +1,67 @@
-import { useState } from "react";
+import { useEffect, useId, useState } from "react";
 import { Menu, X } from "lucide-react";
-import { NavLink } from "react-router-dom";
+import { Link, NavLink, useNavigate } from "react-router-dom";
+import { clearSession } from "../session/clearSession";
 
 const NavBar = () => {
   const [isOpen, setIsOpen] = useState(false);
+  const navigate = useNavigate();
+  const mobileMenuId = useId();
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setIsOpen(false);
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [isOpen]);
+
+  const handleLogout = () => {
+    clearSession();
+    navigate("/sign-in", { replace: true });
+  };
 
   return (
     <nav className="relative ">
       <div className=" px-5 md:px-10 py-5 w-full">
         <div className="flex justify-between items-center">
-          <div className="shrink-0 flex items-center gap-3 cursor-pointer">
+          <Link
+            to="/"
+            className="shrink-0 flex items-center gap-3 cursor-pointer rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F9BC07] focus-visible:ring-offset-2 focus-visible:ring-offset-[#01100F]"
+          >
             <img
               src="/logo.svg"
-              alt="LogiQuest"
+              alt=""
               className="h-16 w-auto object-contain"
             />
             <span className="font-prompt font-bold text-[#CFFDED] text-[31px]">
-              <span>Logi</span>
-              <span>Quest</span>
+              <span className="sr-only">LogiQuest home</span>
+              <span aria-hidden="true">
+                <span>Logi</span>
+                <span>Quest</span>
+              </span>
             </span>
-          </div>
+          </Link>
 
-          {/* DESKTOP */}
           <div className="hidden xl:flex items-center ">
             <div className="flex justify-center text-base text-[#F9BC07] items-center gap-3">
               <NavLink
                 to="/"
                 className={({ isActive }) =>
                   isActive
-                    ? "text-white font-bold"
-                    : "cursor-pointer hover:text-white transition-colors"
+                    ? "text-white font-bold rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F9BC07] focus-visible:ring-offset-2 focus-visible:ring-offset-[#01100F]"
+                    : "cursor-pointer hover:text-white transition-colors rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F9BC07] focus-visible:ring-offset-2 focus-visible:ring-offset-[#01100F]"
                 }
               >
-               Home
+                Home
               </NavLink>
               <NavLink
                 to="/store"
                 className={({ isActive }) =>
                   isActive
-                    ? "text-white font-bold"
-                    : "cursor-pointer hover:text-white transition-colors"
+                    ? "text-white font-bold rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F9BC07] focus-visible:ring-offset-2 focus-visible:ring-offset-[#01100F]"
+                    : "cursor-pointer hover:text-white transition-colors rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F9BC07] focus-visible:ring-offset-2 focus-visible:ring-offset-[#01100F]"
                 }
               >
                 Store
@@ -49,8 +71,8 @@ const NavBar = () => {
                 to="/game-mode"
                 className={({ isActive }) =>
                   isActive
-                    ? "text-white font-bold"
-                    : "cursor-pointer hover:text-white transition-colors"
+                    ? "text-white font-bold rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F9BC07] focus-visible:ring-offset-2 focus-visible:ring-offset-[#01100F]"
+                    : "cursor-pointer hover:text-white transition-colors rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F9BC07] focus-visible:ring-offset-2 focus-visible:ring-offset-[#01100F]"
                 }
               >
                 Game mode
@@ -60,116 +82,173 @@ const NavBar = () => {
                 to="/settings"
                 className={({ isActive }) =>
                   isActive
-                    ? "text-white font-bold"
-                    : "cursor-pointer hover:text-white transition-colors"
+                    ? "text-white font-bold rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F9BC07] focus-visible:ring-offset-2 focus-visible:ring-offset-[#01100F]"
+                    : "cursor-pointer hover:text-white transition-colors rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F9BC07] focus-visible:ring-offset-2 focus-visible:ring-offset-[#01100F]"
                 }
               >
                 Setting
               </NavLink>
 
-              <div className="flex items-center gap-2 cursor-pointer hover:scale-105 transition-transform">
-                <p>Coins</p>
-                <img src="/coins.svg" alt="Coins" className="h-6 w-auto" />
-              </div>
+              <span className="flex items-center gap-2" aria-hidden="true">
+                <span>Coins</span>
+                <img src="/coins.svg" alt="" className="h-6 w-auto" />
+              </span>
 
-              <div className="flex items-center gap-2 cursor-pointer hover:scale-105 transition-transform">
-                <p>Call a friend</p>
-                <img src="/call.svg" alt="Call" className="h-6 w-auto" />
-              </div>
+              <span className="flex items-center gap-2" aria-hidden="true">
+                <span>Call a friend</span>
+                <img src="/call.svg" alt="" className="h-6 w-auto" />
+              </span>
 
-              <div className="flex items-center gap-2 cursor-pointer hover:scale-105 transition-transform">
-                <p>50:50</p>
-                <img src="/fiftyfifty.svg" alt="50:50" className="h-6 w-auto" />
-              </div>
+              <span className="flex items-center gap-2" aria-hidden="true">
+                <span>50:50</span>
+                <img src="/fiftyfifty.svg" alt="" className="h-6 w-auto" />
+              </span>
 
-              <div className="flex items-center gap-2 cursor-pointer hover:scale-105 transition-transform">
-                <p>Audience</p>
+              <span className="flex items-center gap-2" aria-hidden="true">
+                <span>Audience</span>
                 <img
                   src="/audience.svg"
-                  alt="Audience"
+                  alt=""
                   className="h-6 w-auto"
                 />
-              </div>
+              </span>
 
-              <img
-                src="/bell.svg"
-                alt="Bell"
-                className="h-7 w-7 mx-2 cursor-pointer"
-              />
-              <img
-                src="/logout.svg"
-                alt="Logout"
-                className="h-7 cursor-pointer"
-              />
-              <img
-                src="/manfists.png"
-                alt="Profile"
-                className="w-11 h-11 ml-2 object-cover"
-              />
+              <button
+                type="button"
+                className="p-0 mx-2 border-0 bg-transparent cursor-pointer rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F9BC07] focus-visible:ring-offset-2 focus-visible:ring-offset-[#01100F]"
+                aria-label="Notifications"
+              >
+                <img src="/bell.svg" alt="" className="h-7 w-7" />
+              </button>
+              <button
+                type="button"
+                onClick={handleLogout}
+                className="p-0 border-0 bg-transparent cursor-pointer rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F9BC07] focus-visible:ring-offset-2 focus-visible:ring-offset-[#01100F]"
+                aria-label="Log out"
+              >
+                <img src="/logout.svg" alt="" className="h-7" />
+              </button>
+              <NavLink
+                to="/settings"
+                aria-label="Account settings"
+                className="ml-2 rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F9BC07] focus-visible:ring-offset-2 focus-visible:ring-offset-[#01100F]"
+              >
+                <img
+                  src="/manfists.png"
+                  alt=""
+                  className="w-11 h-11 object-cover"
+                />
+              </NavLink>
             </div>
           </div>
 
-          {/* MOBILE TOGGLE */}
           <div className="xl:hidden flex items-center">
             <button
+              type="button"
               onClick={() => setIsOpen(!isOpen)}
-              className="text-[#F9BC07]"
+              className="text-[#F9BC07] rounded-sm p-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F9BC07] focus-visible:ring-offset-2 focus-visible:ring-offset-[#01100F]"
+              aria-expanded={isOpen}
+              aria-controls={mobileMenuId}
+              aria-label={isOpen ? "Close menu" : "Open menu"}
             >
-              {isOpen ? <X size={32} /> : <Menu size={32} />}
+              {isOpen ? <X size={32} aria-hidden /> : <Menu size={32} aria-hidden />}
             </button>
           </div>
         </div>
       </div>
 
-      {/* MOBILE MENU */}
-      {isOpen && (
-        <div className="xl:hidden bg-[#323336] w-full px-10 pb-10 flex flex-col gap-6 absolute top-full left-0 z-50 border-t border-gray-800 shadow-2xl">
+      {isOpen ? (
+        <div
+          id={mobileMenuId}
+          className="xl:hidden bg-[#323336] w-full px-10 pb-10 flex flex-col gap-6 absolute top-full left-0 z-50 border-t border-gray-800 shadow-2xl"
+          role="presentation"
+        >
           <div className="flex flex-col text-base text-[#F9BC07] gap-6 pt-5">
-            <NavLink to="/" onClick={() => setIsOpen(false)}>
+            <NavLink
+              to="/"
+              onClick={() => setIsOpen(false)}
+              className="rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F9BC07] focus-visible:ring-offset-2 focus-visible:ring-offset-[#323336]"
+            >
               Home
             </NavLink>
-            <NavLink to="/store" onClick={() => setIsOpen(false)}>
+            <NavLink
+              to="/store"
+              onClick={() => setIsOpen(false)}
+              className="rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F9BC07] focus-visible:ring-offset-2 focus-visible:ring-offset-[#323336]"
+            >
               Store
             </NavLink>
 
-            <NavLink to="/game-mode" onClick={() => setIsOpen(false)}>
+            <NavLink
+              to="/game-mode"
+              onClick={() => setIsOpen(false)}
+              className="rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F9BC07] focus-visible:ring-offset-2 focus-visible:ring-offset-[#323336]"
+            >
               Game mode
             </NavLink>
 
-            <NavLink to="/settings" onClick={() => setIsOpen(false)}>
+            <NavLink
+              to="/settings"
+              onClick={() => setIsOpen(false)}
+              className="rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F9BC07] focus-visible:ring-offset-2 focus-visible:ring-offset-[#323336]"
+            >
               Setting
             </NavLink>
 
-            <div className="flex flex-col gap-6">
+            <div className="flex flex-col gap-6" aria-hidden="true">
               <div className="flex items-center gap-2">
                 <p>Coins</p>
-                <img src="/coins.png" className="h-6 w-auto" />
+                <img src="/coins.png" className="h-6 w-auto" alt="" />
               </div>
               <div className="flex items-center gap-2">
                 <p>Call</p>
-                <img src="/call.png" className="h-6 w-auto" />
+                <img src="/call.png" className="h-6 w-auto" alt="" />
               </div>
               <div className="flex items-center gap-2">
                 <p>50:50</p>
-                <img src="/5050.png" className="h-6 w-auto" />
+                <img src="/5050.png" className="h-6 w-auto" alt="" />
               </div>
               <div className="flex items-center gap-2">
                 <p>Audience</p>
-                <img src="/audience.png" className="h-6 w-auto" />
+                <img src="/audience.png" className="h-6 w-auto" alt="" />
               </div>
             </div>
 
             <div className="flex items-center gap-6 mt-2">
-              <img src="/bell.png" className="h-8 w-auto" />
-              <img src="/logout.png" className="h-8 w-auto" />
-              <img
-                src="/manfists.png"
-                className="w-10 h-10 object-cover rounded-full border border-[#F9BC07]"
-              />
+              <button
+                type="button"
+                className="p-0 border-0 bg-transparent cursor-pointer rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F9BC07] focus-visible:ring-offset-2 focus-visible:ring-offset-[#323336]"
+                aria-label="Notifications"
+              >
+                <img src="/bell.png" className="h-8 w-auto" alt="" />
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setIsOpen(false);
+                  handleLogout();
+                }}
+                className="p-0 border-0 bg-transparent cursor-pointer rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F9BC07] focus-visible:ring-offset-2 focus-visible:ring-offset-[#323336]"
+                aria-label="Log out"
+              >
+                <img src="/logout.png" className="h-8 w-auto" alt="" />
+              </button>
+              <NavLink
+                to="/settings"
+                onClick={() => setIsOpen(false)}
+                aria-label="Account settings"
+                className="rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F9BC07] focus-visible:ring-offset-2 focus-visible:ring-offset-[#323336]"
+              >
+                <img
+                  src="/manfists.png"
+                  className="w-10 h-10 object-cover rounded-full border border-[#F9BC07]"
+                  alt=""
+                />
+              </NavLink>
             </div>
           </div>
         </div>
-      )}
+      ) : null}
     </nav>
   );
 };

--- a/src/components/gameplay/GameHeader.tsx
+++ b/src/components/gameplay/GameHeader.tsx
@@ -7,63 +7,82 @@ import audience from '../../assets/images/pngs/audience.png';
 import bell from '../../assets/images/pngs/bell.png';
 import avatar from '../../assets/images/pngs/avatar.png';
 
-import { Link } from 'react-router-dom';
+import { Link, NavLink } from 'react-router-dom';
+
+const navItemClass =
+  'hover:text-white transition-colors rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F9BC07] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0a]';
 
 const GameHeader = () => {
   return (
     <header className="flex items-center justify-between bg-[#0a0a0a] px-8 py-4 text-white border-b border-gray-800">
-      <Link 
-        to="/" 
-        className="flex items-center gap-3 hover:opacity-80 transition-opacity cursor-pointer group"
+      <Link
+        to="/"
+        className="flex items-center gap-3 hover:opacity-80 transition-opacity cursor-pointer group rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F9BC07] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0a]"
       >
         <div className="w-10 h-10">
-          <img src={logiQuest} alt="LogiQuest Logo" className="w-full h-full" />
+          <img src={logiQuest} alt="" className="w-full h-full" />
         </div>
         <h1 className="text-2xl font-bold tracking-tight text-white group-hover:text-yellow-500 transition-colors">
-          LogiQuest
+          <span className="sr-only">LogiQuest home</span>
+          <span aria-hidden="true">LogiQuest</span>
         </h1>
       </Link>
 
-      {/* Center Section: Navigation Links */}
-      <nav className="flex items-center gap-8 text-[#d4af37] font-medium text-sm">
-        <button className="hover:text-white transition-colors">Store</button>
-        <button className="hover:text-white transition-colors">Game mode</button>
-        <button className="hover:text-white transition-colors">Setting</button>
+      <nav className="flex items-center gap-8 text-[#d4af37] font-medium text-sm" aria-label="Game navigation">
+        <NavLink to="/store" className={navItemClass}>
+          Store
+        </NavLink>
+        <NavLink to="/game-mode" className={navItemClass}>
+          Game mode
+        </NavLink>
+        <NavLink to="/settings" className={navItemClass}>
+          Setting
+        </NavLink>
       </nav>
 
-      {/* Right Section: Stats & Icons */}
       <div className="flex items-center gap-6">
-        {/* Coins Stat */}
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2" aria-hidden="true">
           <span className="text-[#d4af37] text-sm font-medium">Coins</span>
-          <img src={coinsIcon} alt="Coins" className="w-10 h-10" />
+          <img src={coinsIcon} alt="" className="w-10 h-10" />
         </div>
 
-        {/* Call a Friend */}
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2" aria-hidden="true">
           <span className="text-[#d4af37] text-sm font-medium whitespace-nowrap">Call a friend</span>
-          <img src={callAFriend} alt="Call friend" className="w-10 h-10" />
+          <img src={callAFriend} alt="" className="w-10 h-10" />
         </div>
 
-        {/* 50:50 Lifeline */}
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2" aria-hidden="true">
           <span className="text-sm font-medium">50 : 50</span>
-          <img src={fiftyFifty} alt="Lifeline" className="w-10 h-10" />
+          <img src={fiftyFifty} alt="" className="w-10 h-10" />
         </div>
 
-        {/* Audience Lifeline */}
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2" aria-hidden="true">
           <span className="text-[#d4af37] text-sm font-medium">Audience</span>
-          <img src={audience} alt="Audience" className="w-10 h-10" />
+          <img src={audience} alt="" className="w-10 h-10" />
         </div>
 
-        {/* Utility Icons (Bell, Door, Avatar) */}
         <div className="flex items-center gap-4 ml-4 border-l border-gray-700 pl-4">
-          <button><img src={bell} alt="Alert" className="w-10 h-10" /></button>
-          <button><img src={door} alt="Exit" className="w-10 h-10" /></button>
-          <div className="w-8 h-8 rounded-full bg-cyan-200 overflow-hidden border border-gray-600">
-             <img src={avatar} alt="Profile" className="w-full h-full object-cover" />
-          </div>
+          <button
+            type="button"
+            className="p-0 border-0 bg-transparent cursor-pointer rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F9BC07] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0a]"
+            aria-label="Notifications"
+          >
+            <img src={bell} alt="" className="w-10 h-10" />
+          </button>
+          <button
+            type="button"
+            className="p-0 border-0 bg-transparent cursor-pointer rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F9BC07] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0a]"
+            aria-label="Exit"
+          >
+            <img src={door} alt="" className="w-10 h-10" />
+          </button>
+          <NavLink
+            to="/settings"
+            aria-label="Account settings"
+            className="block w-8 h-8 rounded-full bg-cyan-200 overflow-hidden border border-gray-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F9BC07] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0a]"
+          >
+            <img src={avatar} alt="" className="w-full h-full object-cover" />
+          </NavLink>
         </div>
       </div>
     </header>

--- a/src/components/modals/DeleteAccountModal.tsx
+++ b/src/components/modals/DeleteAccountModal.tsx
@@ -1,6 +1,10 @@
-import { useEffect, useRef } from "react";
+import { useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { clearSession } from "../../session/clearSession";
+import { useDialogFocusTrap } from "../../hooks/useDialogFocusTrap";
+
+const MODAL_BTN_CLASS =
+  "bg-transparent! cursor-pointer hover:scale-105 transition-all rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F9BC07] focus-visible:ring-offset-2 focus-visible:ring-offset-[#01100F]";
 
 type DeleteAccountModalProps = {
   openModal: boolean;
@@ -14,47 +18,7 @@ export function DeleteAccountModal({
   const modalRef = useRef<HTMLDivElement | null>(null);
   const navigate = useNavigate();
 
-  useEffect(() => {
-    if (!openModal) return;
-
-    const modal = modalRef.current;
-    if (!modal) return;
-
-    const focusableElements = modal.querySelectorAll<HTMLElement>(
-      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
-    );
-
-    const firstElement = focusableElements[0];
-    const lastElement = focusableElements[focusableElements.length - 1];
-
-    firstElement?.focus();
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Tab") {
-        if (e.shiftKey) {
-          if (document.activeElement === firstElement) {
-            e.preventDefault();
-            lastElement?.focus();
-          }
-        } else {
-          if (document.activeElement === lastElement) {
-            e.preventDefault();
-            firstElement?.focus();
-          }
-        }
-      }
-
-      if (e.key === "Escape") {
-        setCloseModal(!openModal);
-      }
-    };
-
-    document.addEventListener("keydown", handleKeyDown);
-
-    return () => {
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [openModal, setCloseModal]);
+  useDialogFocusTrap(modalRef, openModal, () => setCloseModal(false));
 
   const handleDeleteAccount = () => {
     clearSession();
@@ -69,12 +33,14 @@ export function DeleteAccountModal({
           ref={modalRef}
           role="dialog"
           aria-modal="true"
+          aria-labelledby="delete-account-dialog-title"
           className="alert-overlay-modal fixed inset-0 z-50  bg-[#211F1FB2]"
         >
           <div className="px-3 alert-content-modal max-w-146.75 w-full">
             <div className="px-3.5 pt-12.75 pb-9.75 flex justify-center bg-[#01100F] rounded-[20px] p">
               <div className="flex flex-col items-center">
                 <h3
+                  id="delete-account-dialog-title"
                   className={`font-medium text-2xl tracking-widest text-center mb-2 text-[#EE2B22]`}
                 >
                   Are you sure you want to delete your account? This action
@@ -83,30 +49,32 @@ export function DeleteAccountModal({
 
                 <img
                   src="/images/image-modal.svg"
-                  alt="image-modal"
+                  alt=""
                   width={221}
                   height={191}
                 />
 
                 <div className="flex  gap-3 pt-8.25">
                   <button
+                    type="button"
                     onClick={handleDeleteAccount}
-                    className="bg-transparent! cursor-pointer hover:scale-105 transition-all focus:scale-105 focus:outline-none!"
+                    className={MODAL_BTN_CLASS}
                   >
                     <img
                       src="/images/button-yes.svg"
-                      alt="image-modal"
+                      alt="Yes, delete my account"
                       width={208}
                       height={68}
                     />
                   </button>
                   <button
-                    onClick={() => setCloseModal(!openModal)}
-                    className="bg-transparent! cursor-pointer hover:scale-105 transition-all focus:scale-105 focus:outline-none!"
+                    type="button"
+                    onClick={() => setCloseModal(false)}
+                    className={MODAL_BTN_CLASS}
                   >
                     <img
                       src="/images/button-no.svg"
-                      alt="image-modal"
+                      alt="No, keep my account"
                       width={208}
                       height={68}
                     />

--- a/src/components/modals/GameplayModal.tsx
+++ b/src/components/modals/GameplayModal.tsx
@@ -1,5 +1,9 @@
 import { ModalIcon } from "../icons";
 import { useEffect, useRef, useState } from "react";
+import { useDialogFocusTrap } from "../../hooks/useDialogFocusTrap";
+
+const MODAL_BTN_CLASS =
+  "bg-transparent! cursor-pointer hover:scale-105 transition-all rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F9BC07] focus-visible:ring-offset-2 focus-visible:ring-offset-[#01100F]";
 
 type GameplayModalProps = {
   option?: number;
@@ -9,6 +13,8 @@ type GameplayModalProps = {
   centerValue: number;
   rightValue: number;
   mainValue: number;
+  onNext?: () => void;
+  onReplay?: () => void;
 };
 
 export function GameplayModal({
@@ -18,53 +24,24 @@ export function GameplayModal({
   rightValue = 1700,
   mainValue = 3000,
   openModal = true,
+  onNext = () => {},
+  onReplay = () => {},
 }: GameplayModalProps) {
   const [closeModal, setCloseModal] = useState(!openModal);
   const [isExit, setIsExit] = useState(false);
   const modalRef = useRef<HTMLDivElement | null>(null);
 
   const isCongratulation = option === 2;
-  useEffect(() => {
-    if (closeModal) return;
+  const dialogOpen = !closeModal;
 
-    const modal = modalRef.current;
-    if (!modal) return;
+  useDialogFocusTrap(modalRef, dialogOpen, () => setCloseModal(true));
 
-    const focusableElements = modal.querySelectorAll<HTMLElement>(
-      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
-    );
-
-    const firstElement = focusableElements[0];
-    const lastElement = focusableElements[focusableElements.length - 1];
-
-    firstElement?.focus();
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Tab") {
-        if (e.shiftKey) {
-          if (document.activeElement === firstElement) {
-            e.preventDefault();
-            lastElement?.focus();
-          }
-        } else {
-          if (document.activeElement === lastElement) {
-            e.preventDefault();
-            firstElement?.focus();
-          }
-        }
-      }
-
-      if (e.key === "Escape") {
-        setCloseModal(true);
-      }
-    };
-
-    document.addEventListener("keydown", handleKeyDown);
-
-    return () => {
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [closeModal, isExit]);
+  const titleId = "gameplay-modal-title";
+  const titleText = isExit
+    ? "Do you want to quite?"
+    : isCongratulation
+      ? "Congratulation"
+      : "Time out";
 
   useEffect(() => {
     document.body.style.overflow = closeModal ? "auto" : "hidden";
@@ -75,29 +52,27 @@ export function GameplayModal({
 
   return (
     <>
-      {!closeModal ? (
+      {dialogOpen ? (
         <div
           ref={modalRef}
           role="dialog"
           aria-modal="true"
+          aria-labelledby={titleId}
           className="alert-overlay-modal fixed inset-0 z-50  bg-[#211F1FB2]"
         >
           <div className="px-3 alert-content-modal max-w-146.75 w-full">
             <div className="px-3.5 pt-12.75 pb-9.75 flex justify-center bg-[#01100F] rounded-[20px] p">
               <div className="flex flex-col items-center">
                 <h3
+                  id={titleId}
                   className={`font-medium text-[34px]/8.5 tracking-[0.2em] text-center mb-2 ${isExit ? "text-white" : isCongratulation ? "text-[#048179]" : "text-[#EE2B22]"}`}
                 >
-                  {isExit
-                    ? "Do you want to quite?"
-                    : isCongratulation
-                      ? "Congratulation"
-                      : "Time out"}
+                  {titleText}
                 </h3>
 
                 <img
                   src="/images/image-modal.svg"
-                  alt="image-modal"
+                  alt=""
                   width={221}
                   height={191}
                 />
@@ -106,7 +81,9 @@ export function GameplayModal({
                 </div>
 
                 <div className="relative">
-                  <ModalIcon />
+                  <span aria-hidden="true">
+                    <ModalIcon />
+                  </span>
                   <span className="absolute  text-center w-10.75 text-[12px] font-medium left-6.25 top-21.75 text-[#01100f]">
                     {leftValue}
                   </span>
@@ -130,23 +107,27 @@ export function GameplayModal({
                 {isExit ? (
                   <div className="flex  gap-3 pt-8.25">
                     <button
+                      type="button"
                       onClick={() => setCloseModal(true)}
-                      className="bg-transparent! cursor-pointer hover:scale-105 transition-all focus:scale-105 focus:outline-none!"
+                      className={MODAL_BTN_CLASS}
+                      aria-label="Yes, quit"
                     >
                       <img
                         src="/images/button-yes.svg"
-                        alt="image-modal"
+                        alt=""
                         width={208}
                         height={68}
                       />
                     </button>
                     <button
+                      type="button"
                       onClick={() => setIsExit(false)}
-                      className="bg-transparent! cursor-pointer hover:scale-105 transition-all focus:scale-105 focus:outline-none!"
+                      className={MODAL_BTN_CLASS}
+                      aria-label="No, continue playing"
                     >
                       <img
                         src="/images/button-no.svg"
-                        alt="image-modal"
+                        alt=""
                         width={208}
                         height={68}
                       />
@@ -154,29 +135,41 @@ export function GameplayModal({
                   </div>
                 ) : (
                   <div className="flex flex-col gap-2 ">
-                    <button className="bg-transparent! cursor-pointer hover:scale-105 transition-all focus:scale-105 focus:outline-none!">
+                    <button
+                      type="button"
+                      onClick={onNext}
+                      className={MODAL_BTN_CLASS}
+                      aria-label="Next"
+                    >
                       <img
                         src="/images/next.svg"
-                        alt="image-modal"
-                        width={319}
-                        height={53}
-                      />
-                    </button>
-                    <button className="bg-transparent! cursor-pointer hover:scale-105 transition-all focus:scale-105 focus:outline-none!">
-                      <img
-                        src="/images/replay.svg"
-                        alt="image-modal"
+                        alt=""
                         width={319}
                         height={53}
                       />
                     </button>
                     <button
+                      type="button"
+                      onClick={onReplay}
+                      className={MODAL_BTN_CLASS}
+                      aria-label="Replay"
+                    >
+                      <img
+                        src="/images/replay.svg"
+                        alt=""
+                        width={319}
+                        height={53}
+                      />
+                    </button>
+                    <button
+                      type="button"
                       onClick={() => setIsExit(true)}
-                      className="bg-transparent! cursor-pointer hover:scale-105 transition-all focus:scale-105 focus:outline-none!"
+                      className={MODAL_BTN_CLASS}
+                      aria-label="Exit game"
                     >
                       <img
                         src="/images/exit.svg"
-                        alt="image-modal"
+                        alt=""
                         width={319}
                         height={53}
                       />

--- a/src/hooks/useDialogFocusTrap.ts
+++ b/src/hooks/useDialogFocusTrap.ts
@@ -1,0 +1,74 @@
+import { type RefObject, useEffect, useRef } from "react";
+
+const FOCUSABLE_SELECTOR =
+  'button:not([disabled]), [href]:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+function isVisible(el: HTMLElement): boolean {
+  if (!el.isConnected) return false;
+  const style = window.getComputedStyle(el);
+  if (style.visibility === "hidden" || style.display === "none") return false;
+  const rect = el.getBoundingClientRect();
+  return rect.width > 0 && rect.height > 0;
+}
+
+function getFocusableElements(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+    (el) => !el.hasAttribute("disabled") && isVisible(el),
+  );
+}
+
+export function useDialogFocusTrap(
+  containerRef: RefObject<HTMLElement | null>,
+  isActive: boolean,
+  onRequestClose: () => void,
+) {
+  const onRequestCloseRef = useRef(onRequestClose);
+
+  useEffect(() => {
+    onRequestCloseRef.current = onRequestClose;
+  }, [onRequestClose]);
+
+  useEffect(() => {
+    if (!isActive) return;
+    const container = containerRef.current;
+    if (!container) return;
+
+    const previous =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onRequestCloseRef.current();
+        return;
+      }
+      if (e.key !== "Tab") return;
+
+      const focusables = getFocusableElements(container);
+      if (focusables.length === 0) return;
+
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else if (document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+
+    const initial = getFocusableElements(container)[0];
+    queueMicrotask(() => initial?.focus());
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      previous?.focus({ preventScroll: true });
+    };
+  }, [isActive, containerRef]);
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,37 @@
 @import url("https://fonts.googleapis.com/css2?family=Prompt:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap");
 @import "tailwindcss";
 
+@layer base {
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border-width: 0;
+  }
+
+  a:focus-visible,
+  button:focus-visible,
+  input:focus-visible,
+  select:focus-visible,
+  textarea:focus-visible,
+  summary:focus-visible {
+    outline: 2px solid #f9bc07;
+    outline-offset: 2px;
+  }
+
+  button:focus-visible:disabled,
+  input:focus-visible:disabled,
+  select:focus-visible:disabled,
+  textarea:focus-visible:disabled {
+    outline: none;
+  }
+}
+
 :root {
   color: #e6fff6;
   background-color: #01100f;


### PR DESCRIPTION
## Summary
Closes #87.

This change brings primary navigation and modals in line with a keyboard and focus baseline aligned with WCAG 2.1 (keyboard operability, focus visible, no keyboard trap in dialogs, name/role for dialogs and icon controls).

## Changes
- **`useDialogFocusTrap`**: Shared hook for modal containers — saves and restores focus, Tab cycles through visible focusables (re-query on each Tab), Escape calls `onRequestClose`.
- **`Navbar` / `GameplayNavbar`**: Logo/home as real links; mobile menu toggle has `aria-expanded`, `aria-controls`, labeled panel `id`, Escape closes menu; lifeline strip is display-only (no faux clickables); notifications and logout are `button`s with `aria-label`; profile uses `NavLink` to settings; focus-visible gold rings match existing accent (`#F9BC07`).
- **`DeleteAccountModal` / `GameplayModal`**: `role="dialog"`, `aria-modal`, `aria-labelledby` tied to titles; image controls use `type="button"` with visible focus rings (no `outline-none` without replacement); Escape reliably closes.
- **`GameHeader`**: Store, game mode, and settings use `NavLink`; bell/exit as labeled buttons; avatar links to settings.
- **`index.css`**: `.sr-only` utility; base `:focus-visible` outline for native `a`/`button`/form controls (components that use `focus-visible:outline-none` + ring keep a single consistent ring).

## Verification
- `npm run lint` and `npm run build` pass locally.
- **Manual keyboard pass recommended for reviewers**: Tab through desktop and mobile nav (open hamburger, tab inside, Escape); open delete-account modal from settings — trap, Escape, focus return; exercise gameplay modal if reachable in UI.

## Notes
- Global outline uses the same gold as existing ring styling; scoped Tailwind rings on nav/modals override the base outline where applied to avoid double indicators.

Made with [Cursor](https://cursor.com)