### PR TITLE
feat: add reusable loading, empty, and error states for core screens

### DIFF
--- a/src/components/AccountSettings.tsx
+++ b/src/components/AccountSettings.tsx
@@ -7,6 +7,8 @@ import { useAppDispatch, useAppSelector } from '../hooks';
 import { setNotificationSchedule } from '../features/preferences/preferencesSlice';
 import { DeleteAccountModal } from './modals/DeleteAccountModal';
 import { useThemeStore } from '../theme/themeStore';
+import { usePreparedView } from '../hooks/usePreparedView';
+import { SurfaceState } from './state/SurfaceState';
 
 interface ToggleProps {
     label?: string;
@@ -55,6 +57,33 @@ interface SettingsState {
     volume: number;
 }
 
+const defaultSettingsState: SettingsState = {
+    notifications: { schedule: 'Daily' },
+    reminder: { day: 'Monday', time: '14:30' },
+    volume: 37,
+};
+
+const readStoredSettings = (): SettingsState => {
+    const saved = localStorage.getItem('quest_account_settings');
+
+    if (!saved) {
+        return defaultSettingsState;
+    }
+
+    const parsed = JSON.parse(saved) as Partial<SettingsState>;
+
+    return {
+        notifications: {
+            schedule: parsed.notifications?.schedule ?? defaultSettingsState.notifications.schedule,
+        },
+        reminder: {
+            day: parsed.reminder?.day ?? defaultSettingsState.reminder.day,
+            time: parsed.reminder?.time ?? defaultSettingsState.reminder.time,
+        },
+        volume: typeof parsed.volume === 'number' ? parsed.volume : defaultSettingsState.volume,
+    };
+};
+
 const AccountSettings = () => {
     const navigate = useNavigate();
     const dispatch = useAppDispatch();
@@ -63,21 +92,11 @@ const AccountSettings = () => {
     const themePreference = useThemeStore((s) => s.preference);
     const setThemePreference = useThemeStore((s) => s.setPreference);
 
-    const [state, setState] = useState<SettingsState>(() => {
-        const saved = localStorage.getItem('quest_account_settings');
-        if (saved) {
-            try {
-                return JSON.parse(saved);
-            } catch (e) {
-                console.error(e);
-            }
-        }
-        return {
-            notifications: { schedule: 'Daily' },
-            reminder: { day: 'Monday', time: '14:30' },
-            volume: 37,
-        };
+    const { data: preparedState, errorMessage, retry, status } = usePreparedView({
+        load: readStoredSettings,
     });
+
+    const [state, setState] = useState<SettingsState>(defaultSettingsState);
 
     const [activeTab, setActiveTab] = useState<TabOption>('Account');
   
@@ -85,8 +104,31 @@ const AccountSettings = () => {
     const [openModal, setOpenModal] = useState(false);
 
     useEffect(() => {
-        localStorage.setItem('quest_account_settings', JSON.stringify(state));
-    }, [state]);
+        if (preparedState) {
+            setState(preparedState);
+        }
+    }, [preparedState]);
+
+    useEffect(() => {
+        if (preparedState) {
+            const schedule = preparedState.notifications.schedule;
+
+            if (
+                schedule === 'Daily' ||
+                schedule === 'Weekly' ||
+                schedule === 'Monthly' ||
+                schedule === 'Never'
+            ) {
+                dispatch(setNotificationSchedule(schedule));
+            }
+        }
+    }, [dispatch, preparedState]);
+
+    useEffect(() => {
+        if (status === 'ready') {
+            localStorage.setItem('quest_account_settings', JSON.stringify(state));
+        }
+    }, [state, status]);
 
     const handleThemeChange = (newTheme: ThemeOption) => {
         setThemePreference(newTheme);
@@ -103,6 +145,41 @@ const AccountSettings = () => {
 
         setState((prev) => ({ ...prev, notifications: { ...prev.notifications, schedule: val } }));
     };
+
+    if (status === 'loading') {
+        return (
+            <div className="min-h-screen bg-[#141516] text-white font-prompt p-6 md:p-12 lg:px-24">
+                <header className="mb-12">
+                    <h1 className="text-3xl md:text-4xl text-[#0A746D]">Setting</h1>
+                </header>
+                <SurfaceState
+                    status="loading"
+                    title="Loading settings"
+                    description="We’re preparing your account preferences, theme choices, and gameplay controls."
+                />
+            </div>
+        );
+    }
+
+    if (status === 'error') {
+        return (
+            <div className="min-h-screen bg-[#141516] text-white font-prompt p-6 md:p-12 lg:px-24">
+                <header className="mb-12">
+                    <h1 className="text-3xl md:text-4xl text-[#0A746D]">Setting</h1>
+                </header>
+                <SurfaceState
+                    status="error"
+                    title="Settings could not be loaded"
+                    description={
+                        errorMessage ??
+                        'We hit a problem while preparing your settings. Retry to restore this page.'
+                    }
+                    actionLabel="Retry"
+                    onAction={retry}
+                />
+            </div>
+        );
+    }
 
     return (
         <div className="min-h-screen bg-[#141516] text-white font-prompt p-6 md:p-12 lg:px-24">
@@ -253,7 +330,7 @@ const AccountSettings = () => {
                                 <label className="text-[#717171] text-lg block">Notification Schedule</label>
                                 <div className="relative group">
                                     <select
-                                        value={notificationSchedule}
+                                        value={state.notifications.schedule || notificationSchedule}
                                         onChange={(e) => handleNotificationChange(e.target.value)}
                                         className="w-full bg-transparent border-b border-[#353536] text-[#9CA3AF] py-3 pr-10 appearance-none focus:outline-none focus:border-[#F9BC07] cursor-pointer"
                                     >

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -1,17 +1,77 @@
 import type { LeaderboardPlayer } from "@/types";
+import { SurfaceState } from "./state/SurfaceState";
+import { usePreparedView } from "../hooks/usePreparedView";
 
 type Props = {
   players: LeaderboardPlayer[];
 };
 
 export const Leaderboard = ({ players }: Props) => {
+  const { data, errorMessage, retry, status } = usePreparedView({
+    deps: [players],
+    isEmpty: (nextPlayers) => nextPlayers.length === 0,
+    load: () => players,
+  });
+
+  if (status === "loading") {
+    return (
+      <section className="w-full max-w-2xl">
+        <h2 className="text-xl text-[#CFFDED] font-medium mb-6 uppercase tracking-wide border-b-2 border-[#CFFDED] pb-2 inline-block">
+          PLAYERS
+        </h2>
+        <SurfaceState
+          status="loading"
+          title="Loading leaderboard"
+          description="We’re lining up the latest rankings and score totals for this table."
+        />
+      </section>
+    );
+  }
+
+  if (status === "error") {
+    return (
+      <section className="w-full max-w-2xl">
+        <h2 className="text-xl text-[#CFFDED] font-medium mb-6 uppercase tracking-wide border-b-2 border-[#CFFDED] pb-2 inline-block">
+          PLAYERS
+        </h2>
+        <SurfaceState
+          status="error"
+          title="Leaderboard unavailable"
+          description={
+            errorMessage ??
+            "We couldn’t prepare the leaderboard right now. Try again to reload the standings."
+          }
+          actionLabel="Retry"
+          onAction={retry}
+        />
+      </section>
+    );
+  }
+
+  if (status === "empty" || !data) {
+    return (
+      <section className="w-full max-w-2xl">
+        <h2 className="text-xl text-[#CFFDED] font-medium mb-6 uppercase tracking-wide border-b-2 border-[#CFFDED] pb-2 inline-block">
+          PLAYERS
+        </h2>
+        <SurfaceState
+          status="empty"
+          title="No players ranked yet"
+          description="The leaderboard will fill in once matches are completed. Play a round to help kick off the rankings."
+          actionLabel="Start playing"
+          onAction={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+        />
+      </section>
+    );
+  }
+
   return (
     <section className="w-full max-w-2xl">
       <h2 className="text-xl text-[#CFFDED] font-medium mb-6 uppercase tracking-wide border-b-2 border-[#CFFDED] pb-2 inline-block">
         PLAYERS
       </h2>
       <div className="border-2 border-[#323336] rounded-lg p-4 space-y-2">
-        {players.map((player, index) => (
+        {data.map((player, index) => (
           <div
             key={player.id}
             className="flex items-center gap-3 p-2 rounded-lg hover:bg-[#252525] transition-colors border-b border-gray-900/50 last:border-b-0"

--- a/src/components/RecentActivity.tsx
+++ b/src/components/RecentActivity.tsx
@@ -1,17 +1,77 @@
 import type { ActivityItem } from "@/types";
+import { usePreparedView } from "../hooks/usePreparedView";
+import { SurfaceState } from "./state/SurfaceState";
 
 type Props = {
   activities: ActivityItem[];
 };
 
 export const RecentActivity = ({ activities }: Props) => {
+  const { data, errorMessage, retry, status } = usePreparedView({
+    deps: [activities],
+    isEmpty: (nextActivities) => nextActivities.length === 0,
+    load: () => activities,
+  });
+
+  if (status === "loading") {
+    return (
+      <section className="w-full text-white p-4">
+        <h2 className="text-xl font-medium mb-4 uppercase tracking-wide border-b border-gray-700/50 pb-2 inline-block text-[#CFFDED]">
+          Recent
+        </h2>
+        <SurfaceState
+          status="loading"
+          title="Loading recent activity"
+          description="We’re gathering your latest matches, rewards, and progress updates."
+        />
+      </section>
+    );
+  }
+
+  if (status === "error") {
+    return (
+      <section className="w-full text-white p-4">
+        <h2 className="text-xl font-medium mb-4 uppercase tracking-wide border-b border-gray-700/50 pb-2 inline-block text-[#CFFDED]">
+          Recent
+        </h2>
+        <SurfaceState
+          status="error"
+          title="Recent activity is unavailable"
+          description={
+            errorMessage ??
+            "We couldn’t load your latest sessions. Retry to refresh this activity feed."
+          }
+          actionLabel="Retry"
+          onAction={retry}
+        />
+      </section>
+    );
+  }
+
+  if (status === "empty" || !data) {
+    return (
+      <section className="w-full text-white p-4">
+        <h2 className="text-xl font-medium mb-4 uppercase tracking-wide border-b border-gray-700/50 pb-2 inline-block text-[#CFFDED]">
+          Recent
+        </h2>
+        <SurfaceState
+          status="empty"
+          title="No activity yet"
+          description="Your latest matches and rewards will show up here after you complete a game."
+          actionLabel="Explore game modes"
+          onAction={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+        />
+      </section>
+    );
+  }
+
   return (
     <section className="w-full text-white p-4">
       <h2 className="text-xl font-medium mb-4 uppercase tracking-wide border-b border-gray-700/50 pb-2 inline-block text-[#CFFDED]">
         Recent
       </h2>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        {activities.map((activity) => (
+        {data.map((activity) => (
           <div
             key={activity.id}
             className="flex items-center gap-4 bg-[#141516] border border-[#323336] rounded-lg p-4 hover:bg-[#1a1b1c] transition-colors"

--- a/src/components/state/SurfaceState.tsx
+++ b/src/components/state/SurfaceState.tsx
@@ -1,0 +1,116 @@
+import type { ReactNode } from "react";
+import type { PreparedViewStatus } from "../../hooks/usePreparedView";
+
+type SurfaceStateProps = {
+  actionLabel?: string;
+  description: string;
+  onAction?: () => void;
+  status: Exclude<PreparedViewStatus, "ready">;
+  title: string;
+};
+
+const accentStyles: Record<SurfaceStateProps["status"], string> = {
+  empty: "border-[#2B5D58] bg-[#102120]",
+  error: "border-[#6F3428] bg-[#261613]",
+  loading: "border-[#3A3C3E] bg-[#141516]",
+};
+
+const labelStyles: Record<SurfaceStateProps["status"], string> = {
+  empty: "text-[#8EE8CF]",
+  error: "text-[#FFB29F]",
+  loading: "text-[#CFFDED]",
+};
+
+function LoadingOrnament() {
+  return (
+    <div className="space-y-3" aria-hidden="true">
+      <div className="h-3 w-24 rounded-full bg-white/10" />
+      <div className="h-3 w-full rounded-full bg-white/8" />
+      <div className="h-3 w-4/5 rounded-full bg-white/8" />
+      <div className="h-3 w-2/3 rounded-full bg-white/8" />
+    </div>
+  );
+}
+
+function StatusOrb({ status }: { status: SurfaceStateProps["status"] }) {
+  return (
+    <div
+      className={`flex h-14 w-14 items-center justify-center rounded-2xl border ${accentStyles[status]}`}
+      aria-hidden="true"
+    >
+      {status === "loading" ? (
+        <div className="h-6 w-6 animate-spin rounded-full border-2 border-white/20 border-t-[#F9BC07]" />
+      ) : (
+        <span className={`text-2xl font-semibold ${labelStyles[status]}`}>
+          {status === "empty" ? "0" : "!"}
+        </span>
+      )}
+    </div>
+  );
+}
+
+export function SurfaceState({
+  actionLabel,
+  description,
+  onAction,
+  status,
+  title,
+}: SurfaceStateProps) {
+  return (
+    <div
+      className="rounded-3xl border border-[#323336] bg-[#141516] p-6 text-white shadow-[0_24px_80px_rgba(0,0,0,0.25)]"
+      role={status === "error" ? "alert" : "status"}
+    >
+      <div className="flex flex-col gap-5 md:flex-row md:items-start md:justify-between">
+        <div className="flex items-start gap-4">
+          <StatusOrb status={status} />
+          <div className="space-y-2">
+            <p className={`text-xs font-semibold uppercase tracking-[0.3em] ${labelStyles[status]}`}>
+              {status}
+            </p>
+            <h3 className="text-xl font-semibold text-white">{title}</h3>
+            <p className="max-w-xl text-sm leading-6 text-[#A1A1AA]">
+              {description}
+            </p>
+          </div>
+        </div>
+
+        {onAction && actionLabel ? (
+          <button
+            type="button"
+            onClick={onAction}
+            className="inline-flex min-h-11 items-center justify-center rounded-full border border-[#F9BC07] px-5 text-sm font-medium text-[#F9BC07] transition hover:bg-[#F9BC07] hover:text-[#141516]"
+          >
+            {actionLabel}
+          </button>
+        ) : null}
+      </div>
+
+      {status === "loading" ? (
+        <div className="mt-6 rounded-2xl border border-white/5 bg-black/10 p-5">
+          <LoadingOrnament />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+type SurfaceSectionProps = {
+  children: ReactNode;
+  className?: string;
+  fallback: ReactNode;
+  status: PreparedViewStatus;
+};
+
+export function SurfaceSection({
+  children,
+  className = "",
+  fallback,
+  status,
+}: SurfaceSectionProps) {
+  if (status !== "ready") {
+    return <>{fallback}</>;
+  }
+
+  return <div className={className}>{children}</div>;
+}

--- a/src/hooks/usePreparedView.ts
+++ b/src/hooks/usePreparedView.ts
@@ -1,0 +1,85 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export type PreparedViewStatus = "loading" | "ready" | "empty" | "error";
+
+type UsePreparedViewOptions<T> = {
+  delayMs?: number;
+  deps?: ReadonlyArray<unknown>;
+  isEmpty?: (data: T) => boolean;
+  load: () => Promise<T> | T;
+};
+
+type UsePreparedViewResult<T> = {
+  data: T | null;
+  errorMessage: string | null;
+  retry: () => void;
+  status: PreparedViewStatus;
+};
+
+export function usePreparedView<T>({
+  delayMs = 450,
+  deps = [],
+  isEmpty,
+  load,
+}: UsePreparedViewOptions<T>): UsePreparedViewResult<T> {
+  const [status, setStatus] = useState<PreparedViewStatus>("loading");
+  const [data, setData] = useState<T | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [attempt, setAttempt] = useState(0);
+  const loadRef = useRef(load);
+  const isEmptyRef = useRef(isEmpty);
+
+  useEffect(() => {
+    loadRef.current = load;
+  }, [load]);
+
+  useEffect(() => {
+    isEmptyRef.current = isEmpty;
+  }, [isEmpty]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const prepare = async () => {
+      setStatus("loading");
+      setErrorMessage(null);
+
+      try {
+        await new Promise((resolve) => window.setTimeout(resolve, delayMs));
+        const nextData = await loadRef.current();
+
+        if (cancelled) {
+          return;
+        }
+
+        setData(nextData);
+        setStatus(isEmptyRef.current?.(nextData) ? "empty" : "ready");
+      } catch (error) {
+        if (cancelled) {
+          return;
+        }
+
+        const message =
+          error instanceof Error
+            ? error.message
+            : "Something went wrong while preparing this screen.";
+
+        setData(null);
+        setErrorMessage(message);
+        setStatus("error");
+      }
+    };
+
+    void prepare();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [attempt, delayMs, ...deps]);
+
+  const retry = useCallback(() => {
+    setAttempt((value) => value + 1);
+  }, []);
+
+  return { data, errorMessage, retry, status };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -179,3 +179,17 @@ body,
 .contributor-float:nth-child(4) {
   animation-delay: 1.5s;
 }
+
+@keyframes surface-pulse {
+  0%,
+  100% {
+    opacity: 0.45;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+.surface-skeleton {
+  animation: surface-pulse 1.6s ease-in-out infinite;
+}


### PR DESCRIPTION
Closes #86

---

- create a shared surface state pattern for loading, empty, and error UI
- add a prepared-view hook to manage screen readiness and retry behavior
- apply consistent state handling to leaderboard, recent activity, and settings
- provide meaningful empty-state copy, retry actions, and aligned visuals across core pages