### PR TITLE
fix: protect /settings route behind auth guard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import Navbar from "./components/Navbar";
 import GameplayNavbar from "./components/GameplayNavbar";
 import Store from "./pages/Store";
 import GameMode from "./pages/GameMode";
+import ProtectedRoute from "./components/ProtectedRoute";
 
 const Home = () => (
   <>
@@ -46,7 +47,14 @@ function App() {
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/sign-in" element={<SignIn />} />
-        <Route path="/settings" element={<AccountSettings />} />
+        <Route
+          path="/settings"
+          element={
+            <ProtectedRoute>
+              <AccountSettings />
+            </ProtectedRoute>
+          }
+        />
         <Route path="/leaderboard" element={<LeaderboardPage />} />
         <Route path="/get-started" element={<GetStarted />} />
         <Route path="/store" element={<Store />} />

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,0 +1,38 @@
+import { Navigate, useLocation } from "react-router-dom";
+import type { ReactNode } from "react";
+
+const TOKEN_KEY = "quest_token";
+
+const readToken = (): string | null => {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  return (
+    window.localStorage.getItem(TOKEN_KEY) ||
+    window.sessionStorage.getItem(TOKEN_KEY)
+  );
+};
+
+interface ProtectedRouteProps {
+  children: ReactNode;
+  redirectTo?: string;
+}
+
+const ProtectedRoute = ({
+  children,
+  redirectTo = "/sign-in",
+}: ProtectedRouteProps) => {
+  const location = useLocation();
+  const token = readToken();
+
+  if (!token) {
+    return (
+      <Navigate to={redirectTo} replace state={{ from: location.pathname }} />
+    );
+  }
+
+  return <>{children}</>;
+};
+
+export default ProtectedRoute;


### PR DESCRIPTION
## Summary

Closes #72.

The `/settings` route was reachable by direct navigation even in a fresh browser session — the `AccountSettings` component rendered before any auth check, exposing the account UI to unauthenticated users.

This PR introduces a small, reusable `ProtectedRoute` wrapper and uses it to gate `/settings`. Unauthenticated visitors are redirected to `/sign-in` before any protected UI renders.

## What changed

- **`src/components/ProtectedRoute.tsx` (new)** — A `ReactNode`-children wrapper that:
  - Reads the session token synchronously from `localStorage` first, then falls back to `sessionStorage` (matching the dual-storage semantics already present in `src/session/clearSession.ts`, which clears both).
  - If no token is found, returns `<Navigate to="/sign-in" replace />` with the originating path tucked into `location.state.from` so the sign-in flow can round-trip users back later.
  - If a token exists, renders the protected children unchanged.
  - Accepts an optional `redirectTo` prop (defaults to `/sign-in`) so the wrapper can guard other sensitive routes without code duplication.
  - Guards against SSR / non-browser execution by checking `typeof window`.

- **`src/App.tsx`** — Imports `ProtectedRoute` and wraps the `/settings` route:
  ```tsx
  <Route
    path="/settings"
    element={
      <ProtectedRoute>
        <AccountSettings />
      </ProtectedRoute>
    }
  />
  ```
  No other routes were touched in this PR. The wrapper is ready to reuse for additional sensitive routes (e.g., future profile/notifications screens) in follow-up PRs.

## Why this approach

- **Synchronous auth check, zero UI flash.** Auth state in this codebase is a plain localStorage token (see `AuthService.signIn` at `src/services/AuthService.ts:54`). There is no async auth provider or token-refresh bootstrap, so a synchronous check is correct — we return `<Navigate>` before children mount, so no account state renders pre-auth.
- **Dual-storage read.** `clearSession.ts` already removes the token from both `localStorage` and `sessionStorage`, implying both are valid storage targets (Google vs email login paths have historically differed — see #73). Reading from both keeps the guard consistent with the existing cleanup contract.
- **Minimal surface area.** No new dependencies, no context provider, no refactor of `AuthService`. The wrapper is ~25 lines and can be deleted or replaced wholesale if a richer auth layer lands later.
- **No token validation (yet).** Token presence is checked, but expiry/signature are not validated here. That belongs in a follow-up once a shared `useAuth` hook exists — out of scope for #72, which asks specifically for route-level access control.

## Acceptance criteria

- [x] `/settings` redirects unauthenticated users to the sign-in page — `<Navigate to="/sign-in" replace />` fires when no token is present.
- [x] Authenticated users can access `/settings` without interruption — when a token exists in either storage, the wrapper transparently renders `<AccountSettings />`.
- [x] Protected route wrapper is reusable for other sensitive routes — exported as a default `ProtectedRoute` component with a `redirectTo` prop; usage is `<ProtectedRoute>{children}</ProtectedRoute>`.
- [x] No account UI state is rendered before auth is confirmed — the token check runs before children are returned, so `AccountSettings` never mounts for unauthenticated users.

## Test plan

**Manual (recommended):**
- [ ] In a fresh browser session (no `quest_token` in local/session storage), navigate directly to `/settings` → should redirect to `/sign-in`, and the account UI should never flash.
- [ ] Sign in via email/password → navigate to `/settings` → page renders normally.
- [ ] Sign in, then manually clear `quest_token` via DevTools → navigate to `/settings` → redirects to `/sign-in`.
- [ ] Verify the redirect carries `location.state.from === "/settings"` (visible via React DevTools on the `SignIn` page) — enables a future "return to intended page" flow.
- [ ] Regression check: `/`, `/leaderboard`, `/get-started`, `/store`, `/game-mode`, `/sign-in` all still render without requiring auth.

**Automated:**
- `tsc -b` passes.
- `eslint` on touched files passes.
- `vite build` produces a clean production build.

## Notes / follow-ups (out of scope)

- A shared `useAuth` hook + context would let us remove the direct `localStorage` read from inside the guard. Worth considering once more routes need protection.
- Token expiry validation (JWT `exp` check is already done inside `GoogleAuthService`) could be lifted into the guard in a follow-up.
- The inactive `src/routes/AppRoutes.tsx` still contains an unguarded `/settings` route declaration. It is not mounted today (see #79/#74), so it has no runtime effect — leaving it alone here to keep this PR atomic.