### PR TITLE
fix: make mobile navbar icons semantic and keyboard-accessible

### DIFF
--- a/src/components/GameplayNavbar.tsx
+++ b/src/components/GameplayNavbar.tsx
@@ -139,7 +139,7 @@ const NavBar = () => {
   };
 
   return (
-    <nav className="relative ">
+    <nav className="relative " aria-label="Primary">
       <div className=" px-5 md:px-10 py-5 w-full">
         <div className="flex justify-between items-center">
           <Link

--- a/src/components/GameplayNavbar.tsx
+++ b/src/components/GameplayNavbar.tsx
@@ -44,14 +44,16 @@ const NavBar = () => {
                   <Link
                     key={index}
                     to={item.link || "#"}
-                    className="cursor-pointer hover:text-white hover:transition-colors text-[#F9BC07]"
+                    aria-label={item.name ? undefined : item.label}
+                    className="cursor-pointer hover:text-white hover:transition-colors text-[#F9BC07] rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F9BC07] focus-visible:ring-offset-2 focus-visible:ring-offset-black"
                   >
                     {item.image ? (
                       <div className="flex items-center gap-2 cursor-pointer ">
                         {item.name}
                         <img
                           src={item.image}
-                          alt={item.name}
+                          alt={item.name ?? ""}
+                          aria-hidden={item.name ? undefined : true}
                           className="ml-2 object-contain"
                         />
                       </div>
@@ -66,10 +68,13 @@ const NavBar = () => {
 
           <div className="xl:hidden flex items-center">
             <button
+              type="button"
               onClick={() => setIsOpen(!isOpen)}
-              className="text-[#F9BC07]"
+              aria-label={isOpen ? "Close navigation menu" : "Open navigation menu"}
+              aria-expanded={isOpen}
+              className="text-[#F9BC07] rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F9BC07]"
             >
-              {isOpen ? <X size={32} /> : <Menu size={32} />}
+              {isOpen ? <X size={32} aria-hidden="true" /> : <Menu size={32} aria-hidden="true" />}
             </button>
           </div>
         </div>
@@ -102,14 +107,16 @@ const NavBar = () => {
                   onClick={() => setIsOpen(false)}
                   key={index}
                   to={item.link || "#"}
-                  className="cursor-pointer hover:text-white hover:transition-colors text-[#F9BC07]"
+                  aria-label={item.name ? undefined : item.label}
+                  className="cursor-pointer hover:text-white hover:transition-colors text-[#F9BC07] rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F9BC07] focus-visible:ring-offset-2 focus-visible:ring-offset-[#323336]"
                 >
                   {item.image ? (
                     <div className="flex items-center gap-2 cursor-pointer ">
                       {item.name}
                       <img
                         src={item.image}
-                        alt={item.name}
+                        alt={item.name ?? ""}
+                        aria-hidden={item.name ? undefined : true}
                         className="ml-1 object-contain"
                       />
                     </div>
@@ -169,7 +176,7 @@ const dataMenu = [
     link: "#",
     image: "/audience.svg",
   },
-  { image: "/bell.svg", link: "#" },
-  { image: "/logout.svg", link: "#" },
-  { image: "/manfists.png", link: "#" },
+  { label: "Notifications", image: "/bell.svg", link: "#" },
+  { label: "Log out", image: "/logout.svg", link: "#" },
+  { label: "Open profile menu", image: "/manfists.png", link: "#" },
 ];

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -23,7 +23,7 @@ const NavBar = () => {
   };
 
   return (
-    <nav className="relative ">
+    <nav className="relative " aria-label="Primary">
       <div className=" px-5 md:px-10 py-5 w-full">
         <div className="flex justify-between items-center">
           <Link

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -112,10 +112,13 @@ const NavBar = () => {
           {/* MOBILE TOGGLE */}
           <div className="xl:hidden flex items-center">
             <button
+              type="button"
               onClick={() => setIsOpen(!isOpen)}
-              className="text-[#F9BC07]"
+              aria-label={isOpen ? "Close navigation menu" : "Open navigation menu"}
+              aria-expanded={isOpen}
+              className="text-[#F9BC07] rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F9BC07]"
             >
-              {isOpen ? <X size={32} /> : <Menu size={32} />}
+              {isOpen ? <X size={32} aria-hidden="true" /> : <Menu size={32} aria-hidden="true" />}
             </button>
           </div>
         </div>
@@ -143,29 +146,49 @@ const NavBar = () => {
             <div className="flex flex-col gap-6">
               <div className="flex items-center gap-2">
                 <p>Coins</p>
-                <img src="/coins.png" className="h-6 w-auto" />
+                <img src="/coins.png" alt="" aria-hidden="true" className="h-6 w-auto" />
               </div>
               <div className="flex items-center gap-2">
                 <p>Call</p>
-                <img src="/call.png" className="h-6 w-auto" />
+                <img src="/call.png" alt="" aria-hidden="true" className="h-6 w-auto" />
               </div>
               <div className="flex items-center gap-2">
                 <p>50:50</p>
-                <img src="/5050.png" className="h-6 w-auto" />
+                <img src="/5050.png" alt="" aria-hidden="true" className="h-6 w-auto" />
               </div>
               <div className="flex items-center gap-2">
                 <p>Audience</p>
-                <img src="/audience.png" className="h-6 w-auto" />
+                <img src="/audience.png" alt="" aria-hidden="true" className="h-6 w-auto" />
               </div>
             </div>
 
             <div className="flex items-center gap-6 mt-2">
-              <img src="/bell.png" className="h-8 w-auto" />
-              <img src="/logout.png" className="h-8 w-auto" />
-              <img
-                src="/manfists.png"
-                className="w-10 h-10 object-cover rounded-full border border-[#F9BC07]"
-              />
+              <button
+                type="button"
+                aria-label="Notifications"
+                className="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F9BC07] focus-visible:ring-offset-2 focus-visible:ring-offset-[#323336]"
+              >
+                <img src="/bell.png" alt="" aria-hidden="true" className="h-8 w-auto" />
+              </button>
+              <button
+                type="button"
+                aria-label="Log out"
+                className="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F9BC07] focus-visible:ring-offset-2 focus-visible:ring-offset-[#323336]"
+              >
+                <img src="/logout.png" alt="" aria-hidden="true" className="h-8 w-auto" />
+              </button>
+              <button
+                type="button"
+                aria-label="Open profile menu"
+                className="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F9BC07] focus-visible:ring-offset-2 focus-visible:ring-offset-[#323336]"
+              >
+                <img
+                  src="/manfists.png"
+                  alt=""
+                  aria-hidden="true"
+                  className="w-10 h-10 object-cover rounded-full border border-[#F9BC07]"
+                />
+              </button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Closes #76.

> **Update after merging `main`:** while this PR was open, #91 (closing #87) was merged into `main` and applied a comprehensive a11y refactor of both navbars. That refactor independently addresses the mobile-icon-semantics gap reported in #76 — bell/logout/profile became real `<button>` / `<NavLink>` elements with `aria-label`s, decorative images got `alt=""` + `aria-hidden`, and a focus-visible ring landed on every interactive control. To avoid duplicate / conflicting work, the conflict resolution in this branch adopts upstream's version of `Navbar.tsx` and `GameplayNavbar.tsx` verbatim, since it is a strict superset of what this PR set out to do.
>
> On top of that merge, this PR now adds one small **additional** a11y improvement that #91 did not cover: labelling the `<nav>` landmark in both navbars.

## What changed

### Merge of `main`

- `src/components/Navbar.tsx` and `src/components/GameplayNavbar.tsx` — conflict resolved by accepting upstream's #91 implementation. Upstream's version is strictly more complete than the original change in this branch (adds wired logout via `clearSession`, Escape-to-close on the mobile menu, `aria-controls` linking the toggle to the menu via `useId()`, and a typed `MenuEntry` discriminated union in `GameplayNavbar`).

### New on top of the merge

- `src/components/Navbar.tsx` — added `aria-label="Primary"` to the `<nav>` element.
- `src/components/GameplayNavbar.tsx` — same.

This makes the primary nav landmark addressable by screen-reader landmark navigation (e.g., VoiceOver rotor / NVDA D key) with a distinct name. The pattern matches what `src/components/gameplay/GameHeader.tsx:31` already does (`aria-label="Game navigation"`), so the codebase now has consistently labelled `<nav>` landmarks across the gameplay and primary navigation surfaces.

## Why "Primary"

- `GameHeader` already uses `aria-label="Game navigation"` for the in-game nav strip.
- The site-level navbar(s) deserve a complementary, equally-distinct label. "Primary" is the convention used in WAI-ARIA landmark guidance for the main site navigation.
- Both `Navbar` and `GameplayNavbar` are mounted exclusively (only one renders at a time, gated by `App.tsx` via `isHomePage`), so reusing the same label is safe — there is never a duplicate "Primary" landmark in the same DOM.

## Acceptance criteria for #76

All four criteria from the original issue are satisfied — the bulk of them by upstream's #91, plus a small landmark-labelling polish from this PR:

- [x] **Interactive icons are real buttons/links** — bell, logout, and profile in the mobile menu are `<button>` / `<NavLink>` elements (from #91).
- [x] **Accessible labels present** — every interactive icon has a descriptive `aria-label`; decorative images are `aria-hidden="true"` (from #91). The `<nav>` landmark itself is now also named, via this PR.
- [x] **Keyboard support** — native `<button>` / `<a>` elements are in the tab order with default Enter/Space activation (from #91); Escape closes the mobile menu (from #91).
- [x] **Focus behavior** — `focus-visible:ring-2 ring-[#F9BC07]` is applied across interactive controls (from #91).

## Test plan

**Automated**
- `tsc -b` passes.
- `eslint` on touched files passes.
- `vite build` produces a clean production build.

**Screen reader / keyboard**
- [ ] In VoiceOver / NVDA / TalkBack, list landmarks → expect to see "Primary, navigation" alongside "Game navigation" (when on a game screen).
- [ ] Press the landmark-jump key (`D` in NVDA, VO+U → Landmarks in VoiceOver) → "Primary" landmark is reachable and named.
- [ ] On a narrow viewport: open the mobile menu, Tab through bell/logout/profile, confirm focus rings render and Enter activates each control. Confirm Esc closes the menu.
- [ ] Logout button on mobile genuinely logs the user out (`clearSession` + redirect to `/sign-in`) — behavior provided by #91, regression-checked here.

## Notes

- The original commit on this branch (`fix: make mobile navbar icons semantic and keyboard-accessible`) is preserved in history but is fully superseded by the merge from `main`. Squash-merging will collapse cleanly.
- Wiring of the bell/notifications icon, additional protected routes, and unification of duplicate route definitions are tracked under separate issues (#80, #79/#74, #77/#71) and are intentionally out of scope here.