### PR TITLE
fix: add wildcard 404 route with home navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import Navbar from "./components/Navbar";
 import GameplayNavbar from "./components/GameplayNavbar";
 import Store from "./pages/Store";
 import GameMode from "./pages/GameMode";
+import NotFound from "./pages/NotFound";
 
 const Home = () => (
   <>
@@ -51,14 +52,7 @@ function App() {
         <Route path="/get-started" element={<GetStarted />} />
         <Route path="/store" element={<Store />} />
         <Route path="/game-mode" element={<GameMode />} />
-        <Route
-          path="*"
-          element={
-            <div className="h-screen flex items-center justify-center text-white text-2xl">
-              404 — Page Not Found
-            </div>
-          }
-        />
+        <Route path="*" element={<NotFound />} />
       </Routes>
     </>
   );

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,0 +1,16 @@
+import { Link } from "react-router-dom";
+
+export default function NotFound() {
+  return (
+    <div className="h-screen flex flex-col items-center justify-center gap-4 text-white">
+      <h1 className="text-6xl font-bold">404</h1>
+      <p className="text-xl text-gray-400">Page not found</p>
+      <Link
+        to="/"
+        className="mt-4 px-6 py-2 bg-white text-black rounded-full font-medium hover:bg-gray-200 transition"
+      >
+        Go Home
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
- Extract NotFound component to src/pages/NotFound.tsx
- Replace inline div wildcard route in App.tsx with NotFound component
- 404 page includes a Go Home link for user recovery

closes #78 