### PR TITLE
fix: resolve broken /store and /game-mode nav routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,14 +43,17 @@ function App() {
         <Routes>
           <Route path="/" element={<Home />} />
           {routeConfig
-            .filter((route) => route.isLazy && route.component)
-            .map((route) => (
-              <Route
-                key={route.path}
-                path={route.path}
-                element={<route.component />}
-              />
-            ))}
+            .filter((route): route is typeof route & { component: NonNullable<typeof route.component> } => route.isLazy && !!route.component)
+            .map((route) => {
+              const Component = route.component;
+              return (
+                <Route
+                  key={route.path}
+                  path={route.path}
+                  element={<Component />}
+                />
+              );
+            })}
           <Route
             path="*"
             element={

--- a/src/components/GameplayNavbar.tsx
+++ b/src/components/GameplayNavbar.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useId, useState } from "react";
+import { useId, useState } from "react";
 import { Menu, X } from "lucide-react";
-import { Link, NavLink, useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { Link as ScrollLink } from "react-scroll";
 
 

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,11 +1,15 @@
-import { useEffect, useId, useState } from "react";
+import { useId, useState } from "react";
 import { Menu, X } from "lucide-react";
-import { NavLink } from "react-router-dom";
+import { Link, NavLink, useNavigate } from "react-router-dom";
 import { getNavItems } from '../config/routes';
 
 const NavBar = () => {
   const [isOpen, setIsOpen] = useState(false);
   const navItems = getNavItems('main');
+
+  const mobileMenuId = useId();
+  const navigate = useNavigate();
+  const handleLogout = () => { navigate('/sign-in'); };
 
   return (
     <nav className="relative " aria-label="Primary">

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -1,4 +1,16 @@
 import { lazy } from 'react';
+import type { ComponentType } from 'react';
+
+type NavType = 'landing' | 'main';
+
+interface RouteConfig {
+  path: string;
+  label: string;
+  showInNav: boolean;
+  navType?: NavType;
+  isLazy: boolean;
+  component?: ComponentType;
+}
 
 // Lazy load components for better performance
 const SignIn = lazy(() => import('../pages/auth/SignIn'));
@@ -10,7 +22,7 @@ const GameMode = lazy(() => import('../pages/GameMode'));
 
 // Route configuration with metadata
 // Note: Home component is defined inline in App.tsx, so it's not lazy-loaded
-export const routeConfig = [
+export const routeConfig: RouteConfig[] = [
   {
     path: '/',
     label: 'Home',
@@ -63,12 +75,12 @@ export const routeConfig = [
     navType: 'main',
     isLazy: true,
   },
-] as const;
+];
 
 // Helper to get navigation items by navbar type
-export const getNavItems = (navType: 'landing' | 'main' | 'both' = 'both') =>
+export const getNavItems = (navType: NavType | 'both' = 'both') =>
   routeConfig.filter(
     (route) =>
       route.showInNav &&
-      (navType === 'both' || route.navType === navType || route.navType === 'both')
+      (navType === 'both' || route.navType === navType)
   );

--- a/src/pages/GetStarted.tsx
+++ b/src/pages/GetStarted.tsx
@@ -1,7 +1,7 @@
-export function GetStarted() {
+export default function GetStarted() {
   return (
     <div className="text-black flex justify-center">
-      <h2>Ge Started</h2>
+      <h2>Get Started</h2>
     </div>
   );
 }


### PR DESCRIPTION
Closes #77

---

Fixes broken top-nav routes for Store and Game Mode.

   Changes made:
   - routes.ts: added RouteConfig interface and proper typing so /store and /game-mode are registered
   - App.tsx: fixed component type narrowing so lazy routes render correctly
   - Navbar.tsx: fixed missing imports and declarations
   - GameplayNavbar.tsx: removed unused imports causing build errors
   - GetStarted.tsx: changed to default export so lazy() resolves correctly

   Tested locally - /store and /game-mode both render correctly.