### PR TITLE
fix: unify auth session persistence across email and Google login (#73)

### DIFF
--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,4 +1,3 @@
-
 import { useNavigate } from "react-router-dom";
 
 export default function NotFound() {
@@ -6,47 +5,35 @@ export default function NotFound() {
 
   return (
     <div className="flex min-h-screen items-center justify-center p-8">
-      <div className="w-full max-w-[500px] rounded-xl border border-white/10  p-8 text-center shadow-2xl backdrop-blur-md">
-        {/* Animated Icon Container */}
+      <div className="w-full max-w-[500px] rounded-xl border border-white/10 p-8 text-center shadow-2xl backdrop-blur-md">
         <div className="animate-pulse text-6xl mb-4">
           <span>🧭</span>
         </div>
-        
+
         <h1 className="text-2xl font-bold text-white mb-4">
           404 - Route Coordinates Lost
         </h1>
-        
+
         <p className="text-sm text-slate-400 leading-relaxed mb-8">
           The system path you requested does not exist or has been shifted across the stellar network. Let's get you back on track.
         </p>
 
         <div className="flex flex-wrap gap-4 justify-center">
-          {/* Action 1: Go Back */}
-          <button 
-            className="px-6 py-3 text-sm font-semibold rounded-md cursor-pointer transition-colors bg-slate-800 text-slate-200 hover:bg-slate-700" 
+          <button
+            className="px-6 py-3 text-sm font-semibold rounded-md cursor-pointer transition-colors bg-slate-800 text-slate-200 hover:bg-slate-700"
             onClick={() => navigate(-1)}
           >
             Go Back
           </button>
 
-          {/* Action 2: Return Home */}
-          <button 
-            className="px-6 py-3 text-sm font-semibold rounded-md cursor-pointer transition-colors bg-blue-600 text-white hover:bg-blue-500" 
+          <button
+            className="px-6 py-3 text-sm font-semibold rounded-md cursor-pointer transition-colors bg-blue-600 text-white hover:bg-blue-500"
             onClick={() => navigate("/")}
           >
             Return Home
           </button>
         </div>
       </div>
-    <div className="h-screen flex flex-col items-center justify-center gap-4 text-white">
-      <h1 className="text-8xl font-bold text-[#CFFDED]">404</h1>
-      <p className="text-xl text-gray-400">Page not found</p>
-      <Link
-        to="/"
-        className="mt-4 px-6 py-2 bg-[#CFFDED] text-black rounded-full font-medium hover:bg-gray-200 transition"
-      >
-        Go Home
-      </Link>
     </div>
   );
 }

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -20,7 +20,7 @@ export default function SignInPage() {
     try {
       if (response.credential) {
         const result = await GoogleAuthService.handleSignIn(response.credential);
-        
+
         if (result.success && result.user) {
           setUser(result.user);
         } else {
@@ -39,6 +39,11 @@ export default function SignInPage() {
     setIsLoading(false);
   };
 
+  const handleSignOut = () => {
+    setUser(null);
+    GoogleAuthService.logout();
+  };
+
   return (
     <div style={containerStyle}>
       <GoogleOAuthProvider clientId={clientId}>
@@ -48,7 +53,7 @@ export default function SignInPage() {
               <img src={user.picture} alt="Profile" referrerPolicy="no-referrer" style={profileImgStyle} />
               <h2>Welcome, {user.name}</h2>
               <p style={{ color: '#666' }}>{user.email}</p>
-              <button onClick={() => setUser(null)} style={buttonStyle}>Sign Out</button>
+              <button onClick={handleSignOut} style={buttonStyle}>Sign Out</button>
             </div>
           ) : (
             <div>
@@ -62,8 +67,8 @@ export default function SignInPage() {
               )}
 
               <div style={{ opacity: isLoading ? 0.5 : 1, pointerEvents: isLoading ? 'none' : 'auto' }}>
-                <GoogleLogin 
-                  onSuccess={onSuccess} 
+                <GoogleLogin
+                  onSuccess={onSuccess}
                   onError={onError}
                   useOneTap={true}
                   use_fedcm_for_prompt={false}
@@ -80,8 +85,6 @@ export default function SignInPage() {
     </div>
   );
 }
-
-// --- Simple Inline Styles for Clarity ---
 
 const containerStyle: React.CSSProperties = {
   display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center',

--- a/src/services/AuthService.ts
+++ b/src/services/AuthService.ts
@@ -1,4 +1,5 @@
 import { clearSession } from "../session/clearSession";
+import { setSession } from "../session/setSession";
 
 const API_BASE = import.meta.env.VITE_BACKEND_API_URL || "";
 
@@ -51,11 +52,8 @@ export const AuthService = {
         };
       }
 
-      if (data.token) {
-        localStorage.setItem("quest_token", data.token);
-      }
-      if (data.user) {
-        localStorage.setItem("quest_user", JSON.stringify(data.user));
+      if (data.token && data.user) {
+        setSession({ token: data.token, user: data.user });
       }
 
       return {

--- a/src/services/GoogleAuthService.ts
+++ b/src/services/GoogleAuthService.ts
@@ -1,5 +1,6 @@
 import { jwtDecode } from "jwt-decode";
 import { clearSession } from "../session/clearSession";
+import { setSession } from "../session/setSession";
 
 interface GoogleJwtPayload {
   email: string;
@@ -24,7 +25,6 @@ export interface AuthServiceResponse {
 
 export const GoogleAuthService = {
   async handleSignIn(credential: string): Promise<AuthServiceResponse> {
-
     try {
       if (!credential) {
         return { success: false, error: "No ID token received from Google." };
@@ -32,21 +32,21 @@ export const GoogleAuthService = {
 
       const decoded = jwtDecode<GoogleJwtPayload>(credential);
 
-      // Security Check: Is the token expired?
       const currentTime = Date.now() / 1000;
       if (decoded.exp < currentTime) {
         return { success: false, error: "The Google session has expired. Please sign in again." };
       }
 
-      return {
-        success: true,
-        user: {
-          email: decoded.email,
-          name: decoded.name,
-          picture: decoded.picture,
-          id: decoded.sub
-        }
+      const user: GoogleUser = {
+        email: decoded.email,
+        name: decoded.name,
+        picture: decoded.picture,
+        id: decoded.sub,
       };
+
+      setSession({ token: credential, user });
+
+      return { success: true, user };
 
     } catch (error) {
       console.error("JWT Decode Error:", error);

--- a/src/session/clearSession.ts
+++ b/src/session/clearSession.ts
@@ -11,8 +11,6 @@ const LOCAL_STORAGE_KEYS = [
   'quest_notification_schedule',
 ] as const;
 
-const SESSION_STORAGE_KEYS = ['quest_token', 'quest_user'] as const;
-
 const removeKeys = (
   storage: Pick<Storage, 'removeItem'> | undefined,
   keys: readonly string[],
@@ -29,11 +27,8 @@ const removeKeys = (
 export function clearSession() {
   const localStorageRef =
     typeof window !== 'undefined' ? window.localStorage : undefined;
-  const sessionStorageRef =
-    typeof window !== 'undefined' ? window.sessionStorage : undefined;
 
   removeKeys(localStorageRef, LOCAL_STORAGE_KEYS);
-  removeKeys(sessionStorageRef, SESSION_STORAGE_KEYS);
 
   queryClient.clear();
   store.dispatch(resetPreferences());

--- a/src/session/setSession.ts
+++ b/src/session/setSession.ts
@@ -1,0 +1,12 @@
+import type { AuthUser } from '../services/AuthService';
+
+export interface SessionPayload {
+  token: string;
+  user: AuthUser;
+}
+
+export function setSession({ token, user }: SessionPayload): void {
+  if (typeof window === 'undefined') return;
+  localStorage.setItem('quest_token', token);
+  localStorage.setItem('quest_user', JSON.stringify(user));
+}


### PR DESCRIPTION
closes #73 

## Summary
Fixes #73 — email and Google auth flows now use a single session contract for token storage and logout.

## Root Cause
`AuthService` (email flow) was writing `quest_token` and `quest_user` to localStorage on success. `GoogleAuthService` was only returning the user to the caller, which stored it in React state only — meaning Google sessions vanished on any navigation or page refresh. Logout behavior also differed: the Google sign-out button was calling `setUser(null)` without clearing storage.

## Changes
- `src/session/setSession.ts` — new shared write path for both providers
- `src/services/AuthService.ts` — replaced inline localStorage calls with `setSession`
- `src/services/GoogleAuthService.ts` — added `setSession` call after successful decode
- `src/session/clearSession.ts` — removed dead sessionStorage block (nothing writes to it)
- `src/pages/SignIn.tsx` — fixed sign-out button to call `GoogleAuthService.logout()` instead of only clearing React state

## Noticed During Fix
The Google button in `src/pages/auth/SignIn.tsx` has no `onClick` handler and is non-functional. This is a pre-existing issue unrelated to #73. A separate issue should be created and can be assigned to me to fix.