### PR TITLE
fix(a11y): wire up FAQ accordion ARIA attributes + fix LogiQuest typo

### DIFF
--- a/src/components/FaqsSection.tsx
+++ b/src/components/FaqsSection.tsx
@@ -1,11 +1,11 @@
-import { useState } from "react";
+﻿import { useState } from "react";
 
 const faqs = [
   {
     id: 1,
-    question: "What is LogiGuest?",
+    question: "What is LogiQuest?",
     answer:
-      "LogiGuest is an interactive web-based game designed to test your logic and knowledge through various fun and challenging game modes.",
+      "LogiQuest is an interactive web-based game designed to test your logic and knowledge through various fun and challenging game modes.",
   },
   {
     id: 2,
@@ -75,6 +75,9 @@ const FaqsSection = () => {
               <button
                 onClick={() => toggle(faq.id)}
                 className="w-full flex justify-between items-center py-4 md:py-5 text-left"
+                aria-expanded={openIds.includes(faq.id)}
+                aria-controls={`faq-${faq.id}-panel`}
+                id={`faq-${faq.id}-q`}
               >
                 <span className="text-lg md:text-xl font-semibold text-white pr-4">
                   {faq.question}
@@ -93,6 +96,9 @@ const FaqsSection = () => {
 
               {/* Answers */}
               <div
+                role="region"
+                id={`faq-${faq.id}-panel`}
+                aria-labelledby={`faq-${faq.id}-q`}
                 className={`overflow-hidden transition-all duration-300 ${openIds.includes(faq.id) ? "max-h-96 py-4" : "max-h-0"
                   }`}
               >
@@ -107,3 +113,5 @@ const FaqsSection = () => {
 };
 
 export default FaqsSection;
+
+


### PR DESCRIPTION
  closes #116 

`FaqsSection.tsx` renders a visual accordion, but it isn't exposed as one to assistive technology:

- Toggle buttons have no `aria-expanded`, so screen readers can't announce open/closed state
- Toggle buttons have no `aria-controls`, so there's no programmatic link between a question and its answer
- Answer panels have no `role="region"` or `id`, so they aren't identifiable landmarks
- The first FAQ reads "What is LogiGuest?" instead of "What is LogiQuest?" (every other FAQ spells it correctly)

## Fix

- Added `aria-expanded={openIds.includes(faq.id)}` to each toggle button, reflecting live state
- Added `aria-controls={`faq-${faq.id}-panel`}` on each button, and a matching `id={`faq-${faq.id}-q`}` so it's a valid `aria-labelledby` target
- Wrapped each answer in `<div role="region" id={`faq-${faq.id}-panel`} aria-labelledby={`faq-${faq.id}-q`}>`, completing the button ↔ panel relationship
- Fixed "LogiGuest" → "LogiQuest" in both the question and answer text

## Testing

- `npx eslint src/components/FaqsSection.tsx` → clean, zero warnings
- `npm run build` → no new errors. Build currently fails on 6 pre-existing TypeScript syntax errors in `src/components/AccountSettings.tsx` (unclosed JSX tags, unrelated to this change) — confirmed identical error count/content before and after this diff, so nothing here regresses the build
- Manually verified `aria-expanded` toggles `true`/`false` correctly per FAQ, and each button/panel `id` pair is unique per `faq.id`

## Acceptance criteria

- [x] `aria-expanded`, `aria-controls`, `role="region"`, and `aria-labelledby` all correctly wired — should resolve accordion violations in Axe/Lighthouse audits
- [x] "LogiGuest" typo fully removed from source